### PR TITLE
Further fix help screen formatting

### DIFF
--- a/blink/message.c
+++ b/blink/message.c
@@ -57,7 +57,9 @@ void PrintMessageBox(int fd, const char *msg, long tyn, long txn) {
   AppendStr(&b, "╗ ");
   AppendFmt(&b, "\033[%d;%dH ║  %-*s  ║ ", y++, x, w - 8, "");
   for (i = 0; i < lines->n; ++i) {
-    AppendFmt(&b, "\033[%d;%dH ║  %-*s  ║ ", y++, x, w - 8, lines->p[i]);
+    int lw = strwidth(lines->p[i], 0);
+    AppendFmt(&b, "\033[%d;%dH ║  %s%-*s  ║ ", y++, x, lines->p[i],
+                                               w - 8 - lw, "");
   }
   FreeLines(lines);
   AppendFmt(&b, "\033[%d;%dH ║  %-*s  ║ ", y++, x, w - 8, "");


### PR DESCRIPTION
Hello @jart,

This patch fixes a remaining minor problem in the formatting of the help screen &mdash; following up on @ghaerr's patch (https://github.com/jart/blink/pull/3):
```
00009a21          50                    push    %rax                            
00009a22          54                    push    %rsp                            
000                                                                             
000 ╔════════════════════════════════════════════════════════════════════╗      
000 ║                                                                    ║      
000 ║  BLINK v1.o                 https://justine.lol/blinkenlights/  ║ 4f8(%rip
000 ║                                                                    ║      
000 ║  KEYBOARD SHORTCUTS                 CLI FLAGS                      ║      
000 ║                                                                    ║      
000 ║  ctrl-c  interrupt                  -t       tui mode              ║      
000 ║  s       step                       -r       real mode             ║     
...
```

The problem was that the top line (`BLINK v1.o` etc.) contains `ESC [` ... control sequences, so directly laying it out with the format string `"...%-*s..."` does not quite work, and causes the number of trailing spaces to be calculated wrong.

I will send you the required copyright assignment e-mail for this project soon.

Thank you!