### PR TITLE
Extend cygwin support to Windows XP SP3

### DIFF
--- a/blink/random.c
+++ b/blink/random.c
@@ -37,6 +37,12 @@
 #include "blink/errno.h"
 #include "blink/random.h"
 #include "blink/types.h"
+#if defined(__CYGWIN__)
+#include <stdbool.h>
+#include <w32api/_mingw.h>
+#define RtlGenRandom SystemFunction036
+bool __stdcall SystemFunction036(void* RandomBuffer, __LONG32 RandomBufferLength);
+#endif
 
 static ssize_t GetDevRandom(char *p, size_t n) {
   int fd;
@@ -77,6 +83,8 @@ ssize_t GetRandom(void *p, size_t n) {
     (defined(__FreeBSD__) || \
      (defined(__NetBSD__) && __NetBSD_Version__ >= 400000000))
   rc = GetKernArnd((char *)p, n);
+#elif defined(__CYGWIN__)
+  rc = RtlGenRandom(p, n) ? n : -1;
 #else
   rc = -1;
 #endif

--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -958,11 +958,13 @@ static int XlatSendFlags(int flags) {
   int supported, hostflags;
   supported = MSG_OOB_LINUX |        //
               MSG_DONTROUTE_LINUX |  //
-              MSG_DONTWAIT_LINUX |   //
 #ifdef MSG_NOSIGNAL
               MSG_NOSIGNAL_LINUX |  //
 #endif
-              MSG_EOR_LINUX;
+#ifdef MSG_EOR
+              MSG_EOR_LINUX |
+#endif
+              MSG_DONTWAIT_LINUX;
   if (flags & ~supported) {
     LOGF("unsupported %s flags %#x", "send", flags & ~supported);
     return einval();
@@ -974,7 +976,9 @@ static int XlatSendFlags(int flags) {
 #ifdef MSG_NOSIGNAL
   if (flags & MSG_NOSIGNAL_LINUX) hostflags |= MSG_NOSIGNAL;
 #endif
+#ifdef MSG_EOR
   if (flags & MSG_EOR_LINUX) hostflags |= MSG_EOR;
+#endif
   return hostflags;
 }
 


### PR DESCRIPTION
[Original windows branch](https://github.com/JoshuaWierenga/blink/tree/add_windows_support) got too complicated and was largely redundant after 74ca808bfe5c9ed8203e00d1bfe0e54ab2741c2b so broke out the remaining xp changes into a separate branch.

Includes Cygwin and MinGW's [weird decision](https://github.com/mirror/mingw-w64/blob/7a411b6ae3bb1e83ed932b493dac044e7c62be1c/mingw-w64-headers/crt/_mingw.h.in#L18-L27) to make LONG actually become 64 bit on x86_64 unlike Windows so I have to use __LONG32 to make things work properly. 