### PR TITLE
Add GitHub Actions workflows for Cygwin (Windows) and macOS

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -26,7 +26,7 @@ jobs:
           usesh: true
           mem: 4096
           prepare: pkg install -y gmake curl
-          run: gmake -j$(sysctl -n hw.ncpu) check o//test/blink o//test/func
+          run: gmake -j$(sysctl -n hw.ncpu) check o//test/blink
 
   build_OpenBSD:
     runs-on: macos-latest
@@ -40,4 +40,4 @@ jobs:
           usesh: true
           mem: 4096
           prepare: pkg_add gmake curl
-          run: gmake -j$(sysctl -n hw.ncpu) check o//test/blink o//test/func
+          run: gmake -j$(sysctl -n hw.ncpu) check o//test/blink

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -1,0 +1,43 @@
+name: Build on FreeBSD and OpenBSD
+
+on:
+  push:
+    branches:
+      - "master"
+      - "flake"
+      - "ga"
+  pull_request:
+    branches:
+      - "master"
+
+  # run workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_FreeBSD:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: make matrix in FreeBSD
+        uses: vmactions/freebsd-vm@0e75f75eeeb07540cb785035b0a307b487ee3aaf
+        with:
+          usesh: true
+          mem: 4096
+          prepare: pkg install -y gmake curl
+          run: gmake -j$(sysctl -n hw.ncpu) check o//test/blink o//test/func
+
+  build_OpenBSD:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: make matrix in OpenBSD
+        uses: vmactions/openbsd-vm@c1174d5858c6941c28aaa629acc3b9665c5897dd
+        with:
+          usesh: true
+          mem: 4096
+          prepare: pkg_add gmake curl
+          run: gmake -j$(sysctl -n hw.ncpu) check o//test/blink o//test/func

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,0 +1,40 @@
+name: Build with Cygwin
+
+on:
+  push:
+    branches:
+      - "master"
+      - "flake"
+      - "ga"
+  pull_request:
+    branches:
+      - "master"
+
+  # run workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install cached Cygwin
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: C:\tools\cygwin
+          key: 'cygwin'
+
+      - name: Install Cygwin
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: egor-tensin/setup-cygwin@v4.0.1
+        with:
+          packages: gcc-core make chere
+
+      - name: make matrix
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          make -j$(nproc) check o//test/blink o//test/asm o//test/func
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -36,5 +36,5 @@ jobs:
       - name: make matrix
         run: |
           cd "$GITHUB_WORKSPACE"
-          make -j$(nproc) check o//test/blink o//test/func
+          make -j$(nproc) check o//test/blink
         shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -36,5 +36,5 @@ jobs:
       - name: make matrix
         run: |
           cd "$GITHUB_WORKSPACE"
-          make -j$(nproc) check o//test/blink o//test/asm o//test/func
+          make -j$(nproc) check o//test/blink o//test/func
         shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,24 @@
+name: Build on macOS
+
+on:
+  push:
+    branches:
+      - "master"
+      - "flake"
+      - "ga"
+  pull_request:
+    branches:
+      - "master"
+
+  # run workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: make matrix
+        run: make -j$(nproc) check o//test/blink o//test/asm o//test/func

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,4 +21,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: make matrix
-        run: make -j$(nproc) check o//test/blink o//test/asm o//test/func
+        run: make -j$(nproc) check o//test/blink o//test/func


### PR DESCRIPTION
These are the two other environments supported by GitHub Actions.

Cygwin tests are currently failing. This should be blink's problem and not the Action's problem.