### PR TITLE
[WIP] HaikuOS Support

### DIFF
--- a/blink/cpuid.c
+++ b/blink/cpuid.c
@@ -29,6 +29,7 @@
 #define XNU_     "XNU\0\0\0\0\0\0\0\0\0"
 #define WINDOWS_ "Windows\0\0\0\0\0"
 #define CYGWIN_  "Cygwin\0\0\0\0\0\0"
+#define HAIKU_   "Haiku\0\0\0\0\0\0\0"
 #define UNKNOWN_ "Unknown\0\0\0\0\0\0"
 
 #ifdef __COSMOPOLITAN__
@@ -52,6 +53,8 @@
 #define OS XNU_
 #elif defined(__CYGWIN__)
 #define OS CYGWIN_
+#elif defined(__HAIKU__)
+#define OS HAIKU_
 #else
 #define OS UNKNOWN_
 #endif

--- a/blink/linux.h
+++ b/blink/linux.h
@@ -492,6 +492,10 @@
 #define UTIME_NOW_LINUX  ((1l << 30) - 1l)
 #define UTIME_OMIT_LINUX ((1l << 30) - 2l)
 
+#define ITIMER_REAL_LINUX     0
+#define ITIMER_VIRTUAL_LINUX  1
+#define ITIMER_PROF_LINUX     2
+
 struct iovec_linux {
   u8 base[8];
   u8 len[8];

--- a/blink/lock.h
+++ b/blink/lock.h
@@ -7,4 +7,14 @@
 #define LOCK(x)   unassert(!pthread_mutex_lock(x))
 #define UNLOCK(x) unassert(!pthread_mutex_unlock(x))
 
+#ifdef __HAIKU__
+#include <OS.h>
+#undef UNLOCK
+#define UNLOCK(x)                       \
+  do {                                  \
+    (x)->owner = find_thread(NULL);     \
+    unassert(!pthread_mutex_unlock(x)); \
+  } while (0)
+#endif
+
 #endif /* BLINK_LOCK_H_ */

--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -2532,7 +2532,7 @@ static int SysGetitimer(struct Machine *m, int which, i64 curvaladdr) {
   int rc;
   struct itimerval it;
   struct itimerval_linux git;
-  if ((rc = getitimer(which, &it)) != -1) {
+  if ((rc = getitimer(UnXlatItimer(which), &it)) != -1) {
     XlatItimervalToLinux(&git, &it);
     CopyToUserWrite(m, curvaladdr, &git, sizeof(git));
   }
@@ -2546,7 +2546,7 @@ static int SysSetitimer(struct Machine *m, int which, i64 neuaddr,
   struct itimerval_linux git;
   CopyFromUserRead(m, &git, neuaddr, sizeof(git));
   XlatLinuxToItimerval(&neu, &git);
-  if ((rc = setitimer(which, &neu, &old)) != -1) {
+  if ((rc = setitimer(UnXlatItimer(which), &neu, &old)) != -1) {
     if (oldaddr) {
       XlatItimervalToLinux(&git, &old);
       CopyToUserWrite(m, oldaddr, &git, sizeof(git));

--- a/blink/xlat.c
+++ b/blink/xlat.c
@@ -650,6 +650,20 @@ int UnXlatOpenFlags(int x) {
   return res;
 }
 
+int UnXlatItimer(int x) {
+  switch (x) {
+    case ITIMER_REAL_LINUX:
+      return ITIMER_REAL;
+    case ITIMER_VIRTUAL_LINUX:
+      return ITIMER_VIRTUAL;
+    case ITIMER_PROF_LINUX:
+      return ITIMER_PROF;
+    default:
+      LOGF("%s %#x not supported", "itimer", x);
+      return einval();
+  }
+}
+
 int XlatSockaddrToHost(struct sockaddr_storage *dst,
                        const struct sockaddr_linux *src, u32 srclen) {
   if (srclen < 2) {

--- a/blink/xlat.h
+++ b/blink/xlat.h
@@ -14,6 +14,7 @@
 int UnXlatOpenFlags(int);
 int UnXlatAccMode(int);
 int UnXlatSignal(int);
+int UnXlatItimer(int);
 int XlatAccess(int);
 int XlatClock(int);
 int XlatErrno(int);

--- a/build/config.mk
+++ b/build/config.mk
@@ -8,11 +8,14 @@ IMAGE_BASE_VIRTUAL = 0x23000000
 CFLAGS +=				\
 	-g				\
 	-O2				\
-	-pthread			\
 	-fno-ident			\
 	-fno-common			\
 	-fstrict-aliasing		\
 	-fstrict-overflow
+
+ifneq ($(HOST_OS), Haiku)
+CFLAGS += -pthread
+endif
 
 CPPFLAGS +=				\
 	-iquote.			\
@@ -26,12 +29,21 @@ CPPFLAGS +=				\
 
 LDLIBS +=				\
 	-lm				\
-	-pthread
 
 ifneq ($(HOST_SYSTEM), Darwin)
 ifneq ($(HOST_SYSTEM), OpenBSD)
+ifneq ($(HOST_SYSTEM), Haiku)
 LDLIBS += -lrt
 endif
+endif
+endif
+
+ifneq ($(HOST_SYSTEM), Haiku)
+LDLIBS += -pthread
+endif
+
+ifeq ($(HOST_SYSTEM), Haiku)
+LDLIBS += -lroot -lnetwork -lbsd
 endif
 
 # FreeBSD loads executables to 0x200000 by default which is likely to


### PR DESCRIPTION
This PR tracks the patches made for `blink` to be built on HaikuOS and additional work to be done for `make check` to work on Haiku.

Currently, these tests are still failing:

```
HAIKU_PROBLEMATIC_TESTS = 									\
		o/$(MODE)/third_party/cosmo/2/nanosleep_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/clock_nanosleep_test.com.ok		\
		o/$(MODE)/third_party/cosmo/2/note_test.com.ok					\
		o/$(MODE)/third_party/cosmo/2/mu_test.com.ok					\
		o/$(MODE)/third_party/cosmo/2/setitimer_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/test_suite_ecp.com.ok				\
		o/$(MODE)/third_party/cosmo/2/counter_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/pthread_exit_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/pthread_create_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/pthread_detach_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/pthread_mutex_lock_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/pthread_mutex_lock2_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/pthread_spin_lock_test.com.ok		\
		o/$(MODE)/third_party/cosmo/2/test_suite_aes.cbc.com.ok				\
		o/$(MODE)/third_party/cosmo/2/test_suite_cipher.gcm.com.ok			\
		o/$(MODE)/third_party/cosmo/2/test_suite_ctr_drbg.com.ok			\
		o/$(MODE)/third_party/cosmo/2/test_suite_entropy.com.ok				\
		o/$(MODE)/third_party/cosmo/2/test_suite_mpi.com.ok				\
		o/$(MODE)/third_party/cosmo/2/test_suite_md.com.ok				\
		o/$(MODE)/third_party/cosmo/5/sigaction_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/mu_starvation_test.com.ok		\
		o/$(MODE)/third_party/cosmo/2/dup_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/cv_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/setsockopt_test.com.ok		\
		o/$(MODE)/third_party/cosmo/5/pipe_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/fork_test.com.ok				\
		o/$(MODE)/third_party/cosmo/2/execve_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/cv_wait_example_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/daemon_test.com.ok			\
		o/$(MODE)/third_party/cosmo/2/socket_test.com.ok			\
		o/$(MODE)/third_party/cosmo/5/unix_test.com.ok					\
```

Most of these tests fail at some `syscall`. In the best case, it fails with a weird `errno`, in other cases, with a `ud2` "Undefined instruction" error in the JIT, as mentioned in #35.

Is there any way to see verbose logs of how Cosmopolitan detects the OS? Reading through the codebase, I see that Cosmopolitan implements `syscall`s as some kind of optimized form of assembly that is platform-specific, for example [this](https://github.com/jart/cosmopolitan/blob/master/libc/sysv/calls/__sys_fork.s). I wonder if these assembly calls are routed through `blink` or executed directly on the host's system. If the latter is true, this is a huge problem for  Haiku, since while it conforms to POSIX, it has a very different way of exposing kernel functionality.

Also, this PR, while focusing on support for Haiku, has some other patches that are not Haiku-specific too.