### PR TITLE
Haiku syscall fixes

### DIFF
--- a/blink/xlat.c
+++ b/blink/xlat.c
@@ -365,15 +365,19 @@ int XlatSocketProtocol(int x) {
   }
 }
 
-int XlatSocketLevel(int x) {
+int XlatSocketLevel(int x, int *level) {
+  // Haiku defines SOL_SOCKET as -1
+  int res;
   switch (x) {
-    XLAT(1, SOL_SOCKET);
-    XLAT(6, IPPROTO_TCP);
-    XLAT(17, IPPROTO_UDP);
+    CASE(1, res = SOL_SOCKET);
+    CASE(6, res = IPPROTO_TCP);
+    CASE(17, res = IPPROTO_UDP);
     default:
       LOGF("%s %d not supported yet", "socket level", x);
       return einval();
   }
+  *level = res;
+  return 0;
 }
 
 int XlatSocketOptname(int level, int optname) {

--- a/blink/xlat.h
+++ b/blink/xlat.h
@@ -26,7 +26,7 @@ int XlatRusage(int);
 int XlatShutdown(int);
 int XlatSignal(int);
 int XlatSocketFamily(int);
-int XlatSocketLevel(int);
+int XlatSocketLevel(int, int *);
 int XlatSocketOptname(int, int);
 int XlatSocketProtocol(int);
 int XlatSocketType(int);


### PR DESCRIPTION
- SOL_SOCKET is defined as -1 on Haiku, therefore XlatSocketLevel has to be changed.
- Haiku _recognizes_ PE binaries, but cannot `exec` them. `execve` on Haiku therefore fails but does not return `ENOEXEC` for Cosmopolitan binaries. Adding an additional error code check fixes this.


This is the last fix required for all blink `make check` to pass on Hyclone 😄 