### PR TITLE
Partly implement descriptor caches for segment registers

### DIFF
--- a/blink/address.c
+++ b/blink/address.c
@@ -24,7 +24,7 @@
 #include "blink/x86.h"
 
 i64 GetPc(struct Machine *m) {
-  return m->cs + GetIp(m);
+  return m->cs.base + GetIp(m);
 }
 
 i64 GetIp(struct Machine *m) {
@@ -46,24 +46,24 @@ i64 AddSegment(P, u64 i, u64 s) {
   if (!Sego(rde)) {
     return i + s;
   } else {
-    return i + m->seg[Sego(rde) - 1];
+    return i + m->seg[Sego(rde) - 1].base;
   }
 }
 
 u64 AddressOb(P) {
-  return AddSegment(A, disp, m->ds);
+  return AddSegment(A, disp, m->ds.base);
 }
 
-u64 *GetSegment(P, unsigned s) {
+u64 GetSegmentBase(P, unsigned s) {
   if (s < 6) {
-    return m->seg + s;
+    return m->seg[s].base;
   } else {
     OpUdImpl(m);
   }
 }
 
 i64 DataSegment(P, u64 i) {
-  return AddSegment(A, i, m->ds);
+  return AddSegment(A, i, m->ds.base);
 }
 
 i64 AddressSi(P) {
@@ -80,7 +80,7 @@ i64 AddressSi(P) {
 }
 
 u64 AddressDi(P) {
-  u64 i = m->es;
+  u64 i = m->es.base;
   switch (Eamode(rde)) {
     case XED_MODE_LONG:
       return i + Get64(m->di);

--- a/blink/debug.c
+++ b/blink/debug.c
@@ -321,11 +321,11 @@ const char *GetBacktrace(struct Machine *m) {
          "OPS %-16ld "
          "JIT %-16ld\n\t"
          "%s\n\t",
-         m->cs + MaskAddress(m->mode, m->ip), DescribeOp(m, GetPc(m)),
+         m->cs.base + MaskAddress(m->mode, m->ip), DescribeOp(m, GetPc(m)),
          Get64(m->ax), Get64(m->cx), Get64(m->dx), Get64(m->bx), Get64(m->sp),
          Get64(m->bp), Get64(m->si), Get64(m->di), Get64(m->r8), Get64(m->r9),
          Get64(m->r10), Get64(m->r11), Get64(m->r12), Get64(m->r13),
-         Get64(m->r14), Get64(m->r15), m->fs, m->gs,
+         Get64(m->r14), Get64(m->r15), m->fs.base, m->gs.base,
          GET_COUNTER(instructions_decoded), GET_COUNTER(instructions_jitted),
          g_progname);
 
@@ -335,7 +335,7 @@ const char *GetBacktrace(struct Machine *m) {
   for (i = 0; i < MAX_BACKTRACE_LINES;) {
     if (i) APPEND("\n\t");
     sym = DisFindSym(&dis, rp);
-    APPEND("%012" PRIx64 " %012" PRIx64 " %s", m->ss + bp, rp,
+    APPEND("%012" PRIx64 " %012" PRIx64 " %s", m->ss.base + bp, rp,
            sym != -1 ? dis.syms.stab + dis.syms.p[sym].name : "UNKNOWN");
     if (sym != -1 && rp != dis.syms.p[sym].addr) {
       APPEND("+%#" PRIx64 "", rp - dis.syms.p[sym].addr);
@@ -350,8 +350,8 @@ const char *GetBacktrace(struct Machine *m) {
       APPEND(" [MISALIGN]");
     }
     ++i;
-    if (((m->ss + bp) & 0xfff) > 0xff0) break;
-    if (!(r = LookupAddress(m, m->ss + bp))) {
+    if (((m->ss.base + bp) & 0xfff) > 0xff0) break;
+    if (!(r = LookupAddress(m, m->ss.base + bp))) {
       APPEND(" [CORRUPT FRAME POINTER]");
       break;
     }

--- a/blink/dis.c
+++ b/blink/dis.c
@@ -204,7 +204,7 @@ static long DisAppendOpLines(struct Dis *d, struct Machine *m, i64 addr) {
   long n, symbol;
   struct DisOp op;
   n = 15;
-  ip = addr - m->cs;
+  ip = addr - m->cs.base;
   if ((symbol = DisFindSym(d, ip)) != -1) {
     if (d->syms.p[symbol].addr <= ip &&
         ip < d->syms.p[symbol].addr + d->syms.p[symbol].size) {

--- a/blink/disarg.c
+++ b/blink/disarg.c
@@ -449,7 +449,7 @@ static char *DisJb(struct Dis *d, u64 rde, char *p) {
 
 static char *DisJvds(struct Dis *d, u64 rde, char *p) {
   return DisSym(d, p, RipRelative(d, d->xedd->op.disp),
-                RipRelative(d, d->xedd->op.disp) - (d->m ? d->m->cs : 0));
+                RipRelative(d, d->xedd->op.disp) - (d->m ? d->m->cs.base : 0));
 }
 
 static char *DisAbs(struct Dis *d, u64 rde, char *p) {

--- a/blink/loader.c
+++ b/blink/loader.c
@@ -294,7 +294,7 @@ static bool LoadElf(struct Machine *m, struct Elf *elf, u64 aslr, int fd) {
 }
 
 static void BootProgram(struct Machine *m, struct Elf *elf, size_t codesize) {
-  m->cs = 0;
+  m->cs.sel = m->cs.base = 0;
   m->ip = 0x7c00;
   elf->base = 0x7c00;
   memset(m->system->real, 0, 0x00f00000);

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -151,7 +151,7 @@ static relegated int GetDescriptorMode(u64 d) {
 }
 
 static relegated bool IsProtectedMode(struct Machine *m) {
-  return m->system->cr0 & 1;
+  return m->system->cr0 & CR0_PE;
 }
 
 static relegated void SetSegment(P, unsigned sr, u16 sel, bool jumping) {

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -72,6 +72,18 @@
 #define kBusCount   256       // # load balanced semaphores in virtual bus
 #define kBusRegion  kSemSize  // 16 is sufficient for 8-byte loads/stores
 
+#define CR0_PE 0x01       // protected mode enabled
+#define CR0_MP 0x02       // monitor coprocessor
+#define CR0_EM 0x04       // no x87 fpu present if set
+#define CR0_TS 0x08       // task switched x87
+#define CR0_ET 0x10       // extension type 287 or 387
+#define CR0_NE 0x20       // enable x87 error reporting
+#define CR0_WP 0x00010000 // write protect read-only pages @pl0
+#define CR0_AM 0x00040000 // alignment mask
+#define CR0_NW 0x20000000 // global write-through cache disable
+#define CR0_CD 0x40000000 // global cache disable
+#define CR0_PG 0x80000000 // paging enabled
+
 #define PAGE_V    0x0001  // valid
 #define PAGE_RW   0x0002  // writeable
 #define PAGE_U    0x0004  // permit user-mode access

--- a/blink/memory.c
+++ b/blink/memory.c
@@ -112,7 +112,8 @@ static u64 FindPageTableEntry(struct Machine *m, u64 page) {
 u8 *LookupAddress(struct Machine *m, i64 virt) {
   u8 *host;
   u64 entry, page;
-  if (m->mode != XED_MODE_REAL) {
+  if (m->mode == XED_MODE_LONG ||
+      (m->mode != XED_MODE_REAL && (m->system->cr0 & 0x80000000) != 0)) {
     if (atomic_load_explicit(&m->invalidated, memory_order_relaxed)) {
       ResetTlb(m);
       atomic_store_explicit(&m->invalidated, false, memory_order_relaxed);

--- a/blink/memory.c
+++ b/blink/memory.c
@@ -113,7 +113,7 @@ u8 *LookupAddress(struct Machine *m, i64 virt) {
   u8 *host;
   u64 entry, page;
   if (m->mode == XED_MODE_LONG ||
-      (m->mode != XED_MODE_REAL && (m->system->cr0 & 0x80000000) != 0)) {
+      (m->mode != XED_MODE_REAL && (m->system->cr0 & CR0_PG) != 0)) {
     if (atomic_load_explicit(&m->invalidated, memory_order_relaxed)) {
       ResetTlb(m);
       atomic_store_explicit(&m->invalidated, false, memory_order_relaxed);

--- a/blink/modrm.c
+++ b/blink/modrm.c
@@ -25,7 +25,7 @@
 
 struct AddrSeg LoadEffectiveAddress(const P) {
   u64 i = disp;
-  u64 s = m->ds;
+  u64 s = m->ds.base;
   struct AddrSeg res;
   unassert(!IsModrmRegister(rde));
   if (Eamode(rde) != XED_MODE_REAL) {
@@ -37,14 +37,14 @@ struct AddrSeg LoadEffectiveAddress(const P) {
       } else {
         i += Get64(RegRexbRm(m, rde));
         if (RexbRm(rde) == 4 || RexbRm(rde) == 5) {
-          s = m->ss;
+          s = m->ss.base;
         }
       }
     } else {
       if (SibHasBase(rde)) {
         i += Get64(RegRexbBase(m, rde));
         if (RexbBase(rde) == 4 || RexbBase(rde) == 5) {
-          s = m->ss;
+          s = m->ss.base;
         }
       }
       if (SibHasIndex(rde)) {
@@ -65,12 +65,12 @@ struct AddrSeg LoadEffectiveAddress(const P) {
         i += Get16(m->di);
         break;
       case 2:
-        s = m->ss;
+        s = m->ss.base;
         i += Get16(m->bp);
         i += Get16(m->si);
         break;
       case 3:
-        s = m->ss;
+        s = m->ss.base;
         i += Get16(m->bp);
         i += Get16(m->di);
         break;
@@ -82,7 +82,7 @@ struct AddrSeg LoadEffectiveAddress(const P) {
         break;
       case 6:
         if (ModrmMod(rde)) {
-          s = m->ss;
+          s = m->ss.base;
           i += Get16(m->bp);
         }
         break;

--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -395,7 +395,7 @@ static int SysSpawn(struct Machine *m, u64 flags, u64 stack, u64 ptid, u64 ctid,
   unassert(!pthread_sigmask(SIG_SETMASK, &ss, &oldss));
   tid = m2->tid;
   if (flags & CLONE_SETTLS_LINUX) {
-    m2->fs = tls;
+    m2->fs.base = tls;
   }
   if (flags & CLONE_CHILD_CLEARTID_LINUX) {
     m2->ctid = ctid;
@@ -784,16 +784,16 @@ static int SysArchPrctl(struct Machine *m, int code, i64 addr) {
   u8 buf[8];
   switch (code) {
     case ARCH_SET_GS_LINUX:
-      m->gs = addr;
+      m->gs.base = addr;
       return 0;
     case ARCH_SET_FS_LINUX:
-      m->fs = addr;
+      m->fs.base = addr;
       return 0;
     case ARCH_GET_GS_LINUX:
-      Write64(buf, m->gs);
+      Write64(buf, m->gs.base);
       return CopyToUserWrite(m, addr, buf, 8);
     case ARCH_GET_FS_LINUX:
-      Write64(buf, m->fs);
+      Write64(buf, m->fs.base);
       return CopyToUserWrite(m, addr, buf, 8);
     default:
       return einval();

--- a/blink/uop.c
+++ b/blink/uop.c
@@ -1112,7 +1112,7 @@ MICRO_OP static u64 Truncate32(u64 x) {
   return (u32)x;
 }
 MICRO_OP static i64 Seg(struct Machine *m, u64 d, long s) {
-  return d + m->seg[s];
+  return d + m->seg[s].base;
 }
 MICRO_OP static i64 Base(struct Machine *m, u64 d, long i) {
   return d + Get64(m->weg[i]);


### PR DESCRIPTION
This patch changes the internal implementation of the emulated segment registers, so that each segment register comprises

- a visible portion, containing the selector value (protected/ long mode) or paragraph value (real mode), which is directly accessible via `mov`, `push`, etc.
- a hidden portion, containing the segment base address.

This makes the implementation closer to what is described in the Intel SDM Volume 3A, §3.4.3 (Segment Registers).

This patch allows the third stage bootloader of "Game of Life" (https://github.com/glitzflitz/gameoflife) to run.

The Blinkenlights register display formatting is also changed: if any segment register bases are non-zero, Blinkenlights displays the visible segment value _and_ the segment base for each segment register, e.g.
```
FS  0000 (@00000000)  DS  1fe0 (@0001fe00)  CS  1fe0 (@0001fe00)
GS  0000 (@00000000)  ES  1fe0 (@0001fe00)  SS  1fe0 (@0001fe00)
```