### PR TITLE
Fix Cygwin JIT memory protection after fork

### DIFF
--- a/blink/jit.h
+++ b/blink/jit.h
@@ -155,6 +155,7 @@ int ShutdownJit(void);
 int InitJit(struct Jit *);
 int DestroyJit(struct Jit *);
 int DisableJit(struct Jit *);
+int FixJitProtection(struct Jit *);
 bool CanJitForImmediateEffect(void) nosideeffect;
 bool AppendJit(struct JitBlock *, const void *, long);
 int AbandonJit(struct Jit *, struct JitBlock *);

--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -368,10 +368,9 @@ static int SysFork(struct Machine *m) {
     m->system->isfork = true;
     RemoveOtherThreads(m->system);
 #ifdef __CYGWIN__
-    LOGF("disabling jit due to fork");
-    DestroyJit(&m->system->jit);
-    InitJit(&m->system->jit);
-    DisableJit(&m->system->jit);
+    // Cygwin doesn't seem to properly set the PROT_EXEC
+    // protection for JIT blocks after forking.
+    FixJitProtection(&m->system->jit);
 #endif
   }
   return pid;


### PR DESCRIPTION
Closes #27 

![image](https://user-images.githubusercontent.com/57174311/216775654-e6b1e0d8-f0cb-404a-b1d1-8000aa0edd82.png)

`glxgears` look quite fast.

I decided to put the fix protection to `jit.c` as it looks more like a general JIT stuff and not specific to Cygwin. Hopefully, compilers may be able to optimize this out on platforms that don't use the workaround.