### PR TITLE
Fix utf-8 printing on windows

### DIFF
--- a/blink/blink.c
+++ b/blink/blink.c
@@ -243,6 +243,12 @@ void exit(int status) {
 
 int main(int argc, char *argv[]) {
   SetupWeb();
+  // Ensure utf-8 is printed correctly on windows, this method
+  // has issues(http://stackoverflow.com/a/10884364/4279) but
+  // should work for at least windows 7 and newer.
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  SetConsoleOutputCP(CP_UTF8);
+#endif
   g_blink_path = argc > 0 ? argv[0] : 0;
   GetOpts(argc, argv);
   if (optind_ == argc) PrintUsage(argc, argv, 48, 2);

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -3804,6 +3804,12 @@ int main(int argc, char *argv[]) {
   static struct sigaction sa;
   g_exitdontabort = true;
   SetupWeb();
+  // Ensure utf-8 is printed correctly on windows, this method
+  // has issues(http://stackoverflow.com/a/10884364/4279) but
+  // should work for at least windows 7 and newer.
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  SetConsoleOutputCP(CP_UTF8);
+#endif
   g_blink_path = argc > 0 ? argv[0] : 0;
   react = true;
   tuimode = true;


### PR DESCRIPTION
Includes the SetConsoleOutputCP call we spoke about with the only change being that I found a constant for the code page so it's not a random integer now. Currently, the ifdef specifically checks for msvc, mingw-w64 or cygwin in non posix modes since I am unsure if the issue also occurs on cygwin in posix mode.

Is it also worth including a temporary fix for sizeof(wchar_t) = 2 on windows since that is an issue in at least pty.c?