### PR TITLE
Ensure configure tests run when using mingw-w64

### DIFF
--- a/configure
+++ b/configure
@@ -184,6 +184,12 @@ compile() {
 
 config() {
   PROGRAM="$1"
+  # If running on cygwin, msys2 or wsl then enable testing mingw-w64 produced binaries
+  if test "${CC#*w64-mingw}" != "${CC}"; then
+    RUNPROGRAM="$1.exe"
+  else
+    RUNPROGRAM="$1"
+  fi
   MESSAGE="$2"
   shift 2
   LOG=$(mktemp blink-config.log.XXXXXX)
@@ -198,7 +204,7 @@ config() {
     exit 1
   fi
   if compile -Werror -o "o/tool/config/${PROGRAM}" "tool/config/${PROGRAM}.c" &&
-     run "o/tool/config/${PROGRAM}"; then
+     run "o/tool/config/${RUNPROGRAM}"; then
     printf '%s\n' "${MESSAGE} yes" >&2
     if [ $# -gt 0 ]; then
       "$@"

--- a/tool/config/dev_urandom.c
+++ b/tool/config/dev_urandom.c
@@ -3,6 +3,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef _WIN32
+#error posix /dev does not exist on windows.
+#endif
+
 /*
  * assuming the system is working correctly there's a 1 in
  * 235716896562095165800448 chance this check should flake

--- a/tool/config/rtlgenrandom.c
+++ b/tool/config/rtlgenrandom.c
@@ -1,6 +1,9 @@
 // tests for RtlGenRandom()
 #include <stdbool.h>
+#include <stdlib.h> // Required for __MINGW64_VERSION_MAJOR, not using __MINGW32__ since old MinGW32 also defines it. See https://github.com/cpredef/predef/blob/master/Compilers.md#mingw-and-mingw-w64.
+#ifndef __MINGW64_VERSION_MAJOR
 #include <w32api/_mingw.h>
+#endif
 
 bool __stdcall SystemFunction036(void *, __LONG32);
 


### PR DESCRIPTION
Originally all tests other than flock failed when using mingw-w64 as cc since it sticks `.exe` on the end of all executable names which confuses the configure script into thinking the features test binaries don't exist.

There is also a fix included for random tests not working with dev_urandom checking the host's /dev/random which exists if building on wsl and I assume cygwin despite this obviously not being the case if the resulting blink binary is run from windows directly or on msys. And rtlgenrandom using a header that doesn't exist in mingw-w64's header library, despite this, the function is available. The rtlgenrandom check could be simpler if I knew that cygwin only defined _WIN32 for native building. Otherwise I think every check has to become the mingw-w64 specific check which needs one of a few system headers to be included first.

I have tried enabling pthreads with {i686, x86_64}-w64-mingw32-gcc-10-posix but just get a windows error popup saying libwinpthread-1.dll was not found so need to investigate that.

Additionally, repeated calls to ./configure can cause some tests, mostly memccpy and __int128 to error with either "Text file busy" and at least one error but I can't reproduce it currently.

Edit: Ignore my multiple title changes, I have been up too many hours and apparently can't read my own title correctly.