### PR TITLE
Tweaks for segment selector handling and page table handling

### DIFF
--- a/blink/loader.c
+++ b/blink/loader.c
@@ -358,6 +358,8 @@ static bool LoadElf(struct Machine *m, struct Elf *elf, int fd) {
   bool execstack = true;
   elf->aslr = ChooseAslr(elf->ehdr, elf->size, m->system->brk, &elf->base);
   m->ip = elf->at_entry = elf->aslr + Read64(elf->ehdr->entry);
+  m->cs.sel = USER_CS_LINUX;
+  m->ss.sel = USER_DS_LINUX;
   elf->at_phdr = elf->base + Read64(elf->ehdr->phoff);
   elf->at_phent = Read16(elf->ehdr->phentsize);
   elf->at_phnum = 0;

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -257,6 +257,10 @@ struct System {
   void (*redraw)(bool);
 };
 
+// Default segment selector values in non-metal mode, per Linux 5.9
+#define USER_DS_LINUX 0x2b                 // default selector for ss (N.B.)
+#define USER_CS_LINUX 0x33                 // default selector for cs
+
 struct JitPath {
   int skip;
   int elements;

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -70,6 +70,13 @@
 #define PAGE_XD   0x8000000000000000
 #define PAGE_TA   0x0000fffffffff000  // extended by one bit for raspberry pi
 
+#define SREG_ES 0
+#define SREG_CS 1
+#define SREG_SS 2
+#define SREG_DS 3
+#define SREG_FS 4
+#define SREG_GS 5
+
 #define P                struct Machine *m, u64 rde, i64 disp, u64 uimm0
 #define A                m, rde, disp, uimm0
 #define DISPATCH_NOTHING m, 0, 0, 0
@@ -695,6 +702,10 @@ void LogCodOp(struct Machine *, const char *);
 #define LogCodOp(m, s) (void)0
 #define WriteCod(...)  (void)0
 #endif
+
+MICRO_OP_SAFE u8 Cpl(struct Machine *m) {
+  return m->cs.sel & 3u;
+}
 
 #define BEGIN_NO_PAGE_FAULTS \
   {                          \

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -430,7 +430,7 @@ void *SchlepW(struct Machine *, i64, size_t);
 void *SchlepRW(struct Machine *, i64, size_t);
 bool IsValidMemory(struct Machine *, i64, i64, int);
 int RegisterMemory(struct Machine *, i64, void *, size_t);
-u8 *GetPageAddress(struct System *, u64);
+u8 *GetPageAddress(struct System *, u64, bool);
 u8 *GetHostAddress(struct Machine *, u64, long);
 u8 *AccessRam(struct Machine *, i64, size_t, void *[2], u8 *, bool);
 u8 *BeginLoadStore(struct Machine *, i64, size_t, void *[2], u8 *);

--- a/blink/pml4t.c
+++ b/blink/pml4t.c
@@ -38,7 +38,7 @@ static void FindContiguousMemoryRangesImpl(
   u64 entry;
   i64 i, page;
   for (i = a; i < b; ++i) {
-    entry = Load64(GetPageAddress(m->system, pt) + i * 8);
+    entry = Load64(GetPageAddress(m->system, pt, level == 39) + i * 8);
     if (!(entry & PAGE_V)) continue;
     page = (addr | i << level) << 16 >> 16;
     if (level == 12) {

--- a/test/asm/movsreg.S
+++ b/test/asm/movsreg.S
@@ -1,0 +1,32 @@
+#include "test/asm/mac.inc"
+.globl	_start
+_start:	mov	$3,%r15
+"test jit too":
+
+//	make -j8 o//blink o//test/asm/movsreg.elf
+//	o//blink/blinkenlights -j o//test/asm/movsreg.elf
+
+	.test	"mov cs"
+	mov	%cs,%eax
+	mov	%al,%dl
+	and	$3,%dl
+	cmp	$3,%dl			// default cs should have RPL 3
+	.e
+
+	shr	$2,%ax			// default cs should not be null
+	.ne
+
+	.test	"mov ss"
+	mov	%ss,%eax
+	mov	%al,%dl
+	and	$3,%dl
+	cmp	$3,%dl			// default ss should have RPL 3
+	.e
+
+	shr	$2,%ax
+	.ne				// default ss should not be null
+
+	dec	%r15
+	jnz	"test jit too"
+"test succeeded":
+	.exit


### PR DESCRIPTION
* Allow loading null selector into segment register in some cases (partly addresses https://github.com/jart/blink/issues/53)
* Do not require `PAGE_V` to be set on `cr3` &mdash; when reading top-level page table
* Do not require `PAGE_U` to be set on page table entries, when guest is not running at Ring 3
* Initialize `cs` and `ss` to Ring 3 selector values, when guest is starting in non-metal mode