### PR TITLE
Implement huge virtual memory pages, and fix some minor issues

### DIFF
--- a/blink/disspec.c
+++ b/blink/disspec.c
@@ -511,7 +511,7 @@ const char *DisSpecMap1(struct XedDecodedInst *x, char *p) {
     RCASE(0x76, DisOpPqQqVdqWdq(x, p, "pcmpeqd"));
     RCASE(0x77, "emms");
     RCASE(0x80 ... 0x8f, "jCC Jvds");
-    RCASE(0x90 ... 0x9f, "setCC Jvds");
+    RCASE(0x90 ... 0x9f, "setCC Eb");
     RCASE(0xA0, "push %fs");
     RCASE(0xA1, "pop %fs");
     RCASE(0xA2, "cpuid");

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -1387,9 +1387,11 @@ static relegated void OpMovCqRq(P) {
       break;
     case 3:
       m->system->cr3 = Get64(RegRexbRm(m, rde));
+      ResetTlb(m);
       break;
     case 4:
       m->system->cr4 = Get64(RegRexbRm(m, rde));
+      ResetTlb(m);
       break;
     default:
       OpUdImpl(m);

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -58,9 +58,8 @@
 #define PAGE_V    0x0001  // valid
 #define PAGE_RW   0x0002  // writeable
 #define PAGE_U    0x0004  // permit user-mode access
-#define PAGE_4KB  0x0080  // IsPage (if PDPTE/PDE) or PAT (if PT)
-#define PAGE_2MB  0x0180
-#define PAGE_1GB  0x0180
+#define PAGE_PS   0x0080  // IsPage (if PDPTE/PDE) or PAT (if PT)
+#define PAGE_G    0x0100  // global
 #define PAGE_RSRV 0x0200  // no actual memory associated
 #define PAGE_HOST 0x0400  // PAGE_TA bits point to host (not real) memory
 #define PAGE_MAP  0x0800  // PAGE_TA bits were mmmap()'d


### PR DESCRIPTION
* Fix disassembly of `set`_cc_ instructions &mdash; e.g. `0f 90 c1` should be `seto %cl`
* Reset entire TLB on each `%cr3` or `%cr4` load
  * Intel manual (V3A §2.5) suggests that TLB is flushed on at least _some_ loads into `%cr3` or `%cr4`
* Implement huge (1 GiB / 2 MiB) virtual memory pages (https://github.com/jart/blink/issues/53)