### PR TITLE
VFS: CI and a few small bug fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,15 @@ jobs:
       - name: download ape 3
         run: sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
 
-      - name: configure
+      - name: make matrix
         run: |
           ./configure
           cat config.log
+          make -j$(nproc) check o//test/blink o//test/asm o//test/func o//test/metal
 
-      - name: make matrix
-        run: make -j2 check o//test/blink o//test/asm o//test/func o//test/metal
+      - name: Test with VFS enabled
+        run: |
+          ./configure --enable-vfs
+          cat config.log
+          export BLINK_PREFIX="o"
+          make -j$(nproc) check o//test/blink o//test/asm o//test/func o//test/metal

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -40,3 +40,12 @@ jobs:
           cat config.log
           make -j$(nproc) check o//test/blink
         shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+
+      - name: Test with VFS enabled
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          ./configure --enable-vfs
+          cat config.log
+          export BLINK_PREFIX="o"
+          make -j$(nproc) check o//test/blink
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'

--- a/blink/hostfs.c
+++ b/blink/hostfs.c
@@ -1840,6 +1840,9 @@ cleananddie:
 
 int HostfsFexecve(struct VfsInfo *info, char *const *argv, char *const *envp) {
   struct HostfsInfo *hostinfo;
+#ifndef HAVE_FEXECVE
+  char path[VFS_PATH_MAX];
+#endif
   VFS_LOGF("HostfsFexecve(%p, %p, %p)", info, argv, envp);
 #ifdef HAVE_FEXECVE
   if (info == NULL) {
@@ -1848,7 +1851,10 @@ int HostfsFexecve(struct VfsInfo *info, char *const *argv, char *const *envp) {
   hostinfo = (struct HostfsInfo *)info->data;
   return fexecve(hostinfo->filefd, argv, envp);
 #else
-  return enosys();
+  if (HostfsGetHostPath(info, path) == -1) {
+    return -1;
+  }
+  return execve(path, argv, envp);
 #endif
 }
 

--- a/blink/hostfs.c
+++ b/blink/hostfs.c
@@ -269,15 +269,20 @@ static ssize_t HostfsGetOptimalDirFdName(struct VfsInfo *dir, const char *name,
     } else {
       len2 = strlen(name);
       hostdevice = (struct HostfsDevice *)dir->device->data;
-      ret = hostdevice->sourcelen + len1 + ((len2 == 0) ? 0 : len2 + 1);
+      ret = hostdevice->sourcelen + len1 +
+            // add a slash if the host path doesn't end with one
+            ((len2 == 0) ? 0 : len2 + (hostpath[len1 - 1] != '/'));
       if (ret + 1 >= VFS_PATH_MAX) {
         ret = enametoolong();
       } else {
         memmove(hostpath + hostdevice->sourcelen, hostpath, len1);
         memcpy(hostpath, hostdevice->source, hostdevice->sourcelen);
         if (len2 != 0) {
-          hostpath[hostdevice->sourcelen + len1] = '/';
-          memcpy(hostpath + hostdevice->sourcelen + len1 + 1, name, len2 + 1);
+          if (hostpath[hostdevice->sourcelen + len1 - 1] != '/') {
+            hostpath[hostdevice->sourcelen + len1] = '/';
+            ++len1;
+          }
+          memcpy(hostpath + hostdevice->sourcelen + len1, name, len2 + 1);
         }
         hostpath[ret] = '\0';
       }

--- a/blink/hostfs.c
+++ b/blink/hostfs.c
@@ -1283,7 +1283,8 @@ int HostfsAccept(struct VfsInfo *info, struct sockaddr *addr,
     (*output)->ino = info->ino;
     (*output)->dev = info->dev;
     (*output)->mode = info->mode;
-    (*output)->parent = info->parent;
+    unassert(!VfsFreeInfo((*output)->parent));
+    unassert(!VfsAcquireInfo(info->parent, &(*output)->parent));
     (*output)->refcount = 1;
     ret = 0;
   } else {

--- a/third_party/cosmo/cosmo.mk
+++ b/third_party/cosmo/cosmo.mk
@@ -209,8 +209,13 @@ COSMO_TESTS =											\
 	o/$(MODE)/third_party/cosmo/2/readansi_test.com.ok					\
 	o/$(MODE)/third_party/cosmo/2/sendrecvmsg_test.com.ok					\
 	o/$(MODE)/third_party/cosmo/2/lseek_test.com.ok						\
-	o/$(MODE)/third_party/cosmo/2/mmap_test.com.ok						\
-	o/$(MODE)/third_party/cosmo/7/munmap_test.com.ok
+	o/$(MODE)/third_party/cosmo/2/mmap_test.com.ok
+
+# munmap_test triggers SIGSEGV on purpose, making it fail on asan
+# TODO(jart): Make this work on asan
+ifneq ($(MODE), asan)
+COSMO_TESTS += o/$(MODE)/third_party/cosmo/7/munmap_test.com.ok
+endif
 
 # write_test is broken on Cygwin due to RLIMIT_FSIZE
 # TODO(jart): Why do the other ones flake on Cygwin?


### PR DESCRIPTION
- Added CI builds with `--enable-vfs`.
- Fixed bug when reading `/SystemRoot` on Cygwin.
- Fixed some memory leaks when handling UNIX sockets.
- Added fallback to `execve` on systems without `fexecve` in `HostfsFexecve`.