### PR TITLE
Added missing imports for `--enable-vfs`

### DIFF
--- a/blink/hostfs.c
+++ b/blink/hostfs.c
@@ -26,6 +26,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 
+#include "blink/assert.h"
 #include "blink/errno.h"
 #include "blink/hostfs.h"
 #include "blink/log.h"

--- a/blink/procfs.c
+++ b/blink/procfs.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <threads.h>
 
+#include "blink/atomic.h"
 #include "blink/errno.h"
 #include "blink/log.h"
 #include "blink/machine.h"


### PR DESCRIPTION
`#include "blink/assert.h"` was missing in `blink/hostfs.c` and  `#include "blink/atomic.h"` was missing `blink/procfs.c`
