### PR TITLE
Fix handling of `int` instructions for both metal & non-metal

### DIFF
--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -3078,6 +3078,7 @@ static bool OnHalt(int interrupt) {
     case kMachineDecodeError:
       OnDecodeError();
       return true;
+    case 0:
     case kMachineDivideError:
       OnDivideError();
       return true;
@@ -3618,6 +3619,9 @@ static void Exec(void) {
     if (IsMakingPath(m)) {
       AbandonPath(m);
     }
+    // if sigsetjmp fake-returned 1, the actual trap number might have been
+    // either 1 or 0; this should have been stored in m->trapno
+    if (interrupt == 1) interrupt = m->trapno;
     if (OnHalt(interrupt)) {
       if (!tuimode) {
         goto KeepGoing;
@@ -3783,6 +3787,7 @@ static void Tui(void) {
     if (IsMakingPath(m)) {
       AbandonPath(m);
     }
+    if (interrupt == 1) interrupt = m->trapno;
     if (OnHalt(interrupt)) {
       ReactiveDraw();
       ScrollMemoryViews();

--- a/blink/throw.c
+++ b/blink/throw.c
@@ -95,12 +95,20 @@ void HaltMachine(struct Machine *m, int code) {
       m->faultaddr = m->ip - m->oplen;
       DeliverSignalToUser(m, SIGTRAP_LINUX, SI_KERNEL_LINUX);
       break;
+    case 4:
+      m->faultaddr = 0;
+      DeliverSignalToUser(m, SIGSEGV_LINUX, SI_KERNEL_LINUX);
+      break;
     case kMachineExitTrap:
       RestoreIp(m);
       break;
     default:
-      if (code > 0) {
-        break;
+      if (code >= 0) {
+        if (!m->metal) {
+          RestoreIp(m);
+          m->faultaddr = 0;
+          DeliverSignalToUser(m, SIGSEGV_LINUX, SI_KERNEL_LINUX);
+        }
       } else {
         unassert(!"not possible");
       }


### PR DESCRIPTION
- `int 0` now behaves like a divide by zero in metal mode, but with `cs:ip` pointing _after_ the `int 0`
- In non-metal (Linux) mode, `int` _n_ with _n_ other than 1, 3, or `0x80`, should raise a `SIGSEGV` (`int 0x80` is unimplemented)
- `int 4` in non-metal mode is a bit of a special case