### PR TITLE
Implement some i186+ instructions, and fix a few others

### DIFF
--- a/blink/disarg.c
+++ b/blink/disarg.c
@@ -413,6 +413,16 @@ static char *DisImm(struct Dis *d, u64 rde, char *p) {
                        ZeroExtend(rde, d->xedd->op.uimm0));
 }
 
+static char *DisIw(struct Dis *d, u64 rde, char *p) {
+  return DisSymLiteral(d, rde, p, d->xedd->op.uimm0 & 0xffff,
+                                  d->xedd->op.uimm0 & 0xffff);
+}
+
+static char *DisEnterIb(struct Dis *d, u64 rde, char *p) {
+  return DisSymLiteral(d, rde, p, d->xedd->op.uimm0 >> 16 & 0xff,
+                                  d->xedd->op.uimm0 >> 16 & 0xff);
+}
+
 static char *DisRvds(struct Dis *d, u64 rde, char *p) {
   return DisSymLiteral(d, rde, p, d->xedd->op.disp, d->xedd->op.disp);
 }
@@ -561,7 +571,6 @@ static char *DisWps(struct Dis *d, u64 rde, char *p) {
 #define DisIvds DisImm
 #define DisIvqp DisImm
 #define DisIvs  DisImm
-#define DisIw   DisImm
 #define DisMdi  DisM
 #define DisMdq  DisM
 #define DisMdqp DisM
@@ -633,6 +642,7 @@ static const struct DisArg {
     {"%rAX", DisRax},    //
     {"%rDX", DisRdx},    //
     {"*Eq", DisIndirEq}, //
+    {">Ib", DisEnterIb}, //
     {"BBb", DisBBb},     //
     {"DX", DisPort},     //
     {"EST", DisEst},     //

--- a/blink/disspec.c
+++ b/blink/disspec.c
@@ -530,6 +530,7 @@ const char *DisSpecMap1(struct XedDecodedInst *x, char *p) {
     RCASE(0x02, "lar %Gvqp Ev");
     RCASE(0x03, "lsl %Gvqp Ev");
     RCASE(0x05, "syscall");
+    RCASE(0x06, "clts");
     RCASE(0x09, "wbinvd");
     RCASE(0x0B, "ud2");
     RCASE(0x20, "mov %Hd %Cd");

--- a/blink/disspec.c
+++ b/blink/disspec.c
@@ -726,6 +726,23 @@ const char *DisSpecMap1(struct XedDecodedInst *x, char *p) {
       } else {
         return "bsr %Gvqp Evqp";
       }
+    case 0x00:
+      switch (ModrmReg(x->op.rde)) {
+        case 0:
+          return "sldt Ew";
+        case 1:
+          return "str Ew";
+        case 2:
+          return "lldt Ew";
+        case 3:
+          return "ltr Ew";
+        case 4:
+          return "verr Ew";
+        case 5:
+          return "verw Ew";
+        default:
+          return UNKNOWN;
+      }
     case 0x01:
       switch (ModrmReg(x->op.rde)) {
         case 0:

--- a/blink/disspec.c
+++ b/blink/disspec.c
@@ -227,6 +227,7 @@ const char *DisSpecMap0(struct XedDecodedInst *x, char *p) {
     RCASE(0xC5, "lds %Gv Mp");
     RCASE(0xC6, "mov Eb Ib");
     RCASE(0xC7, "mov Evqp Ivds");
+    RCASE(0xC8, "enter >Ib Iw");
     RCASE(0xC9, "leave");
     RCASE(0xCA, "lret Iw");
     RCASE(0xCB, "lret");

--- a/blink/legacy.c
+++ b/blink/legacy.c
@@ -42,6 +42,21 @@ relegated void OpDecZv(P) {
   }
 }
 
+static relegated void PushaCommon(struct Machine *m, void *b, size_t n) {
+  u32 v;
+  switch (m->mode.omode) {
+    case XED_MODE_REAL:
+      Put16(m->sp, (v = (Get16(m->sp) - n) & 0xffff));
+      break;
+    case XED_MODE_LEGACY:
+      Put64(m->sp, (v = (Get32(m->sp) - n) & 0xffffffff));
+      break;
+    default:
+      __builtin_unreachable();
+  }
+  CopyToUser(m, m->ss.base + v, b, n);
+}
+
 static relegated void Pushaw(P) {
   u16 v;
   u8 b[8][2];
@@ -53,8 +68,7 @@ static relegated void Pushaw(P) {
   memcpy(b[5], m->dx, 2);
   memcpy(b[6], m->cx, 2);
   memcpy(b[7], m->ax, 2);
-  Put16(m->sp, (v = (Read16(m->sp) - sizeof(b)) & 0xffff));
-  CopyToUser(m, m->ss.base + v, b, sizeof(b));
+  PushaCommon(m, b, sizeof(b));
 }
 
 static relegated void Pushad(P) {
@@ -68,22 +82,37 @@ static relegated void Pushad(P) {
   memcpy(b[5], m->dx, 4);
   memcpy(b[6], m->cx, 4);
   memcpy(b[7], m->ax, 4);
-  Put64(m->sp, (v = (Get32(m->sp) - sizeof(b)) & 0xffffffff));
-  CopyToUser(m, m->ss.base + v, b, sizeof(b));
+  PushaCommon(m, b, sizeof(b));
+}
+
+static relegated void PopaCommon(struct Machine *m, void *b, size_t n) {
+  u64 addr;
+  switch (m->mode.omode) {
+    case XED_MODE_REAL:
+      addr = m->ss.base + Read16(m->sp);
+      if (CopyFromUser(m, b, addr, n) == -1) {
+        ThrowSegmentationFault(m, addr);
+      }
+      Put16(m->sp, (Get16(m->sp) + n) & 0xffff);
+      break;
+    case XED_MODE_LEGACY:
+      addr = m->ss.base + Read32(m->sp);
+      if (CopyFromUser(m, b, addr, n) == -1) {
+        ThrowSegmentationFault(m, addr);
+      }
+      Put64(m->sp, (Get32(m->sp) + n) & 0xffffffff);
+      break;
+    default:
+      __builtin_unreachable();
+  }
 }
 
 static relegated void Popaw(P) {
-  u64 addr;
   u8 b[8][2];
-  addr = m->ss.base + Read16(m->sp);
-  if (CopyFromUser(m, b, addr, sizeof(b)) == -1) {
-    ThrowSegmentationFault(m, addr);
-  }
-  Put16(m->sp, (Get32(m->sp) + sizeof(b)) & 0xffff);
+  PopaCommon(m, b, sizeof(b));
   memcpy(m->di, b[0], 2);
   memcpy(m->si, b[1], 2);
   memcpy(m->bp, b[2], 2);
-  memcpy(m->sp, b[3], 2);
   memcpy(m->bx, b[4], 2);
   memcpy(m->dx, b[5], 2);
   memcpy(m->cx, b[6], 2);
@@ -91,17 +120,11 @@ static relegated void Popaw(P) {
 }
 
 static relegated void Popad(P) {
-  u64 addr;
   u8 b[8][4];
-  addr = m->ss.base + Get32(m->sp);
-  if (CopyFromUser(m, b, addr, sizeof(b)) == -1) {
-    ThrowSegmentationFault(m, addr);
-  }
-  Put64(m->sp, (Get32(m->sp) + sizeof(b)) & 0xffffffff);
+  PopaCommon(m, b, sizeof(b));
   memcpy(m->di, b[0], 4);
   memcpy(m->si, b[1], 4);
   memcpy(m->bp, b[2], 4);
-  memcpy(m->sp, b[3], 4);
   memcpy(m->bx, b[4], 4);
   memcpy(m->dx, b[5], 4);
   memcpy(m->cx, b[6], 4);
@@ -109,12 +132,14 @@ static relegated void Popad(P) {
 }
 
 relegated void OpPusha(P) {
-  switch (Eamode(rde)) {
+  switch (m->mode.omode) {
     case XED_MODE_REAL:
-      Pushaw(A);
-      break;
     case XED_MODE_LEGACY:
-      Pushad(A);
+      if (Osz(rde)) {
+        Pushaw(A);
+      } else {
+        Pushad(A);
+      }
       break;
     case XED_MODE_LONG:
       OpUdImpl(m);
@@ -124,12 +149,14 @@ relegated void OpPusha(P) {
 }
 
 relegated void OpPopa(P) {
-  switch (Eamode(rde)) {
+  switch (m->mode.omode) {
     case XED_MODE_REAL:
-      Popaw(A);
-      break;
     case XED_MODE_LEGACY:
-      Popad(A);
+      if (Osz(rde)) {
+        Popaw(A);
+      } else {
+        Popad(A);
+      }
       break;
     case XED_MODE_LONG:
       OpUdImpl(m);

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -1744,7 +1744,7 @@ static const nexgen32e_f kNexgen32e[] = {
     /*0C5*/ OpLds,                   //
     /*0C6*/ OpMovImm,                // #90   (0.004525%)
     /*0C7*/ OpMovImm,                // #45   (0.161349%)
-    /*0C8*/ OpUd,                    //
+    /*0C8*/ OpEnter,                 //
     /*0C9*/ OpLeave,                 // #116  (0.001237%)
     /*0CA*/ OpRetf,                  //
     /*0CB*/ OpRetf,                  //

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -1514,6 +1514,7 @@ static void OpEmms(P) {
 #define OpPopa      OpUd
 #define OpPushSeg   OpUd
 #define OpPusha     OpUd
+#define OpClts      OpUd
 #define OpRdmsr     OpUd
 #define OpRetf      OpUd
 #define OpInto      OpUd
@@ -1805,7 +1806,7 @@ static const nexgen32e_f kNexgen32e[] = {
     /*103*/ OpLsl,                   //
     /*104*/ OpUd,                    //
     /*105*/ OpSyscall,               // #133  (0.000663%)
-    /*106*/ OpUd,                    //
+    /*106*/ OpClts,                  //
     /*107*/ OpUd,                    //
     /*108*/ OpUd,                    //
     /*109*/ OpWbinvd,                //

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -706,6 +706,7 @@ void OpLes(P);
 void OpLds(P);
 void OpJmpf(P);
 void OpJmpfEq(P);
+void OpClts(P);
 void OpRdmsr(P);
 void OpWrmsr(P);
 void OpMovRqCq(P);

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -604,6 +604,7 @@ void OpDivAlAhAxEbSigned(P);
 void OpDivAlAhAxEbUnsigned(P);
 void OpDivRdxRaxEvqpSigned(P);
 void OpDivRdxRaxEvqpUnsigned(P);
+void OpEnter(P);
 void OpImulGvqpEvqp(P);
 void OpImulGvqpEvqpImm(P);
 void OpIncEvqp(P);

--- a/blink/metal.c
+++ b/blink/metal.c
@@ -236,6 +236,14 @@ relegated void OpCallfEq(P) {
   LoadFarPointer(A, SREG_CS, true);
 }
 
+relegated void OpClts(P) {
+  if (Cpl(m)) {
+    ThrowProtectionFault(m);
+  } else {
+    m->system->cr0 &= ~(u64)CR0_TS;
+  }
+}
+
 relegated void OpWrmsr(P) {
   switch (Get32(m->cx)) {
     case MSR_IA32_EFER:

--- a/blink/x86.c
+++ b/blink/x86.c
@@ -260,7 +260,8 @@ static int xed_set_imm_bytes(struct XedDecodedInst *x, int *imm_width,
             x->op.rde)][Osz(x->op.rde)][Mode(x->op.rde)]];
         return XED_ERROR_NONE;
       case 11:
-        *imm_width = xed_bytes2bits(2);
+        // actually 2 bytes for uimm0 & 1 byte for uimm1
+        *imm_width = xed_bytes2bits(3);
         return XED_ERROR_NONE;
       case 12:
         if (Osz(x->op.rde) || Rep(x->op.rde) == 2) {

--- a/test/asm/asm.mk
+++ b/test/asm/asm.mk
@@ -39,7 +39,7 @@ $(TEST_ASM_OBJS): test/asm/asm.mk test/asm/mac.inc
 o/$(MODE)/test/asm/%.com:						\
 		o/$(MODE)/test/asm/%.elf				\
 		o/$(MODE)/blink/blink					\
-		o/third_party/qemu/qemu-x86_64				\
+		o/third_party/qemu/4/qemu-x86_64			\
 		$(VM)
 	@mkdir -p $(@D)
 	@echo "#!/bin/sh" >$@
@@ -51,8 +51,8 @@ o/$(MODE)/test/asm/%.com:						\
 	@echo "o/$(MODE)/blink/blink -m $< || exit" >>$@
 	@echo "echo [test] o/$(MODE)/blink/blink -jm $< >&2" >>$@
 	@echo "o/$(MODE)/blink/blink -jm $< || exit" >>$@
-	@echo "echo [test] o/third_party/qemu/qemu-x86_64 -cpu core2duo $< >&2" >>$@
-	@echo "$(VM) o/third_party/qemu/qemu-x86_64 -cpu core2duo $< || exit" >>$@
+	@echo "echo [test] o/third_party/qemu/4/qemu-x86_64 -cpu core2duo $< >&2" >>$@
+	@echo "$(VM) o/third_party/qemu/4/qemu-x86_64 -cpu core2duo $< || exit" >>$@
 	@chmod +x $@
 
 .PHONY: o/$(MODE)/test/asm

--- a/test/asm/enter.S
+++ b/test/asm/enter.S
@@ -1,0 +1,63 @@
+#include "test/asm/mac.inc"
+.globl	_start
+_start:
+
+//	make -j8 o//blink o//test/asm/enter.elf
+//	o//blink/blinkenlights o//test/asm/enter.elf
+
+#define MAGIC1		0x2b8cfa3db6a78c9a
+#define MAGIC2		0x58b8
+#define MAGIC3		0x225e
+#define MAGIC4		0x4ea0
+
+	.test	"enterq stores frame pointer of size 8"
+	movabs	$MAGIC1,%rbx
+	lea	-8-MAGIC2(%rsp),%rax
+	lea	-8(%rsp),%rcx
+	mov	%rsp,%rdx
+
+	mov	%rbx,%rbp
+	enterq	$MAGIC2,$0
+	cmp	%rsp,%rax
+	.e
+	cmp	%rbp,%rcx
+	.e
+	cmp	(%rbp),%rbx
+	.e
+
+	.test	"leaveq restores frame pointer of size 8"
+	leaveq
+	cmp	%rdx,%rsp
+	.e
+	cmp	%rbx,%rbp
+	.e
+
+	.test	"enterw stores frame pointer of size 2"
+	xor	%sp,%sp			// make sure %sp does not wrap
+	sub	$8,%rsp			// around 64 KiB boundary
+
+	mov	%rsp,%rbx
+	mov	$MAGIC3,%bx
+	lea	-2-MAGIC4(%rsp),%rax
+	lea	-2(%rsp),%rcx
+	mov	%rsp,%rdx
+
+	mov	%rbx,%rbp
+	enterw	$MAGIC4,$0
+	cmp	%rsp,%rax
+	.e
+	cmp	%rbp,%rcx
+	.e
+	cmp	(%rbp),%bx
+	.e
+
+	.test	"leavew restores frame pointer of size 2"
+	leavew
+	cmp	%rdx,%rsp
+	.e
+	mov	%bx,%dx
+	cmp	%rdx,%rbp
+	.e
+
+"test succeeded":
+	.exit

--- a/test/metal/enter.S
+++ b/test/metal/enter.S
@@ -1,0 +1,73 @@
+#include "test/metal/mac.inc"
+
+	.section .head,"ax",@progbits
+	.code16
+
+.globl	_start
+_start:
+
+//	make -j8 o//blink o//test/metal/enter.bin
+//	o//blink/blinkenlights -r o//test/metal/enter.bin
+
+	.load32	_start32
+
+	.section .text,"ax",@progbits
+	.code32
+
+#define MAGIC1		0xacc31274
+#define MAGIC2		0xa7fc
+#define MAGIC3		0x40df
+#define MAGIC4		0x8c34
+
+_start32:
+	.test	"enterl stores frame pointer of size 4"
+	mov	$MAGIC1,%ebx
+	lea	-4-MAGIC2(%esp),%eax
+	lea	-4(%esp),%ecx
+	mov	%esp,%edx
+
+	mov	%ebx,%ebp
+	enterl	$MAGIC2,$0
+	cmp	%esp,%eax
+	.e
+	cmp	%ebp,%ecx
+	.e
+	cmp	(%ebp),%ebx
+	.e
+
+	.test	"leavel restores frame pointer of size 4"
+	leavel
+	cmp	%edx,%esp
+	.e
+	cmp	%ebx,%ebp
+	.e
+
+	.test	"enterw stores frame pointer of size 2"
+	xor	%sp,%sp			// make sure %sp does not wrap
+	sub	$4,%esp			// around 64 KiB boundary
+
+	mov	%esp,%ebx
+	mov	$MAGIC3,%bx
+	lea	-2-MAGIC4(%esp),%eax
+	lea	-2(%esp),%ecx
+	mov	%esp,%edx
+
+	mov	%ebx,%ebp
+	enterw	$MAGIC4,$0
+	cmp	%esp,%eax
+	.e
+	cmp	%ebp,%ecx
+	.e
+	cmp	(%ebp),%bx
+	.e
+
+	.test	"leavew restores frame pointer of size 2"
+	leavew
+	cmp	%edx,%esp
+	.e
+	mov	%bx,%dx
+	cmp	%edx,%ebp
+	.e
+
+"test succeeded":
+	.exit

--- a/test/metal/mac.inc
+++ b/test/metal/mac.inc
@@ -1,0 +1,110 @@
+// -*- mode: unix-assembly; indent-tabs-mode: t; tab-width: 8; coding: utf-8 -*-
+
+	.macro	.load32 entry:req
+	ljmp	$0,$101f
+101:	xor	%ax,%ax
+	mov	%ax,%ds
+	mov	%ax,%es
+	mov	%ax,%ss
+	mov	$_start,%sp
+	int	$0x13			// reset boot device (%ah = 0)
+	mov	$0x0200+_sectors-1,%ax	// read remaining sectors of this
+	mov	$_start+512,%bx		// test case
+	mov	$0x0002,%cx
+	mov	$0,%dh
+	int	$0x13
+	jc	101b
+	cli				// switch to protected mode
+	lgdtl	103f
+	mov	%cr0,%eax
+	or	$1,%al
+	mov	%eax,%cr0
+	jmp	102f
+102:	mov	$16,%ax
+	mov	%ax,%ds
+	mov	%ax,%es
+	mov	%ax,%ss
+	movzwl	0x0413,%esp		// start stack at base memory top
+	shll	$10,%esp
+	ljmpl	$8,$(\entry)		// really transition to 32-bit mode
+	.balign	8
+103:	.short	105f-104f-1
+	.long	104f
+	.balign	8
+104:
+.quad	0b0000000000000000000000000000000000000000000000000000000000000000 # 0
+.quad	0b0000000011001111100110100000000000000000000000001111111111111111 # 8
+.quad	0b0000000011001111100100100000000000000000000000001111111111111111 #16
+105:
+	.endm
+
+	.macro	.exit
+	cli
+	lidtl	%cs:106f
+	xor	%edi,%edi
+	xor	%eax,%eax
+	mov	$231,%al
+	syscall
+	.balign	8
+106:	.quad	0
+	.endm
+
+	.macro	.test name:req
+prologue\@:
+	jmp	101f
+100:	int3
+	hlt
+	jmp	100b
+101:	nop
+"\name":
+	.endm
+
+	.macro	.c
+	jnc	100b
+	.endm
+	.macro	.nc
+	jc	100b
+	.endm
+
+	.macro	.e
+	jne	100b
+	.endm
+	.macro	.ne
+	je	100b
+	.endm
+
+	.macro	.z
+	jnz	100b
+	.endm
+	.macro	.nz
+	jz	100b
+	.endm
+
+	.macro	.s
+	jns	100b
+	.endm
+	.macro	.ns
+	js	100b
+	.endm
+
+	.macro	.o
+	jno	100b
+	.endm
+	.macro	.no
+	jo	100b
+	.endm
+
+	.macro	.p
+	jnp	100b
+	.endm
+	.macro	.np
+	jp	100b
+	.endm
+
+	.macro	.sop
+	.nz
+	.s
+	.nc
+	.o
+	.p
+	.endm

--- a/test/metal/metal.lds
+++ b/test/metal/metal.lds
@@ -5,6 +5,7 @@ SECTIONS {
   . = 0x7c00;
 
   .head : {
+    _base = .;
     *(.head)
 
     /*
@@ -30,8 +31,11 @@ SECTIONS {
 
   .text : {
     *(.text .text.*)
+    . = ALIGN(0x10);
     *(.rodata .rodata.*)
+    . = ALIGN(0x10);
     *(.data .data.*)
+    _edata = .;
   }
 
   .bss : {
@@ -42,4 +46,6 @@ SECTIONS {
   /DISCARD/ : {
     *(.*)
   }
+
+  _sectors = ALIGN(_edata - _base, 512) / 512;
 }

--- a/test/metal/metal.mk
+++ b/test/metal/metal.mk
@@ -24,7 +24,7 @@ o/$(MODE)/test/metal/%.bin:							\
 	@mkdir -p $(@D)
 	$(TEST_METAL_LINK)
 
-$(TEST_METAL_OBJS): test/metal/metal.mk
+$(TEST_METAL_OBJS): test/metal/metal.mk test/metal/mac.inc
 
 o/$(MODE)/test/metal/%.bin.ok:						\
 		o/$(MODE)/test/metal/%.bin				\

--- a/test/metal/pusha-popa.S
+++ b/test/metal/pusha-popa.S
@@ -1,0 +1,307 @@
+	.section .head,"ax",@progbits
+	.code16
+
+.globl	_start
+_start:
+
+//	make -j8 o//blink o//test/metal/pusha-popa.bin
+//	o//blink/blinkenlights -r o//test/metal/pusha-popa.bin
+
+0:	ljmpw	$0,$1f
+
+1:	xor	%ax,%ax
+	mov	%ax,%ds
+	mov	%ax,%es
+	mov	%ax,%ss
+
+	/* longword with high half being z & low half being w */
+#define SMUSH(z, w)	((((z) & 0xffff) << 16) | ((w) & 0xffff))
+
+#define MAGIC0		0x84de
+#define INI_SP		0x7c00
+#define INI_ESP		SMUSH(MAGIC0, INI_SP)
+
+	mov	$INI_ESP,%esp
+
+	int	$0x13			// reset boot device (%ah = 0)
+	mov	$0x0200+_sectors-1,%ax	// read remaining sectors of this
+	mov	$0b+512,%bx		// test case
+	mov	$0x0002,%cx
+	mov	$0,%dh
+	int	$0x13
+	jc	1b
+
+#define MAGIC1		0x6f692002
+#define MAGIC2		0x8556ab1b
+#define MAGIC3		0x1bc6f7f7
+#define MAGIC4		0x60540962
+#define MAGIC5		0xf2b8c5fd
+#define MAGIC6		0x705a9a7f
+#define MAGIC7		0x08500349
+#define MAGIC8		0xdf7601c3
+
+	mov	$MAGIC1,%eax
+	mov	$MAGIC2,%ecx
+	mov	$MAGIC3,%edx
+	mov	$MAGIC4,%ebx
+	mov	$MAGIC5,%ebp
+	mov	$MAGIC6,%esi
+	mov	$MAGIC7,%edi
+	pushal
+/*
+ * now %sp                                                      INI_SP
+ * ↓       +4      +8      +12     +16     +20     +24     +28     ↓
+ * ┌───────┬───────┬───────┬───────┬───────┬───────┬───────┬───────┐
+ * │MAGIC7 │MAGIC6 │MAGIC5 │INI_ESP│MAGIC4 │MAGIC3 │MAGIC2 │MAGIC1 │
+ * └───────┴───────┴───────┴───────┴───────┴───────┴───────┴───────┘
+ *   %edi    %esi    %ebp   initial  %edx    %ecx    %ebx    %eax
+ *                           %esp
+ */
+
+	cmp	$INI_ESP-32,%esp
+	jnz	fail
+	mov	$MAGIC8,%ebp
+	mov	%sp,%bp
+	cmpl	$MAGIC1,28(%bp)
+	jnz	fail
+	cmpl	$MAGIC2,24(%bp)
+	jnz	fail
+	cmpl	$MAGIC3,20(%bp)
+	jnz	fail
+	cmpl	$MAGIC4,16(%bp)
+	jnz	fail
+	cmpl	$INI_ESP,12(%bp)
+	jnz	fail
+	cmpl	$MAGIC5,8(%bp)
+	jnz	fail
+	cmpl	$MAGIC6,4(%bp)
+	jnz	fail
+	cmpl	$MAGIC7,(%bp)
+	jnz	fail
+
+#define MAGIC9		0x63b5007e
+
+	mov	$MAGIC9,%edi
+	addr32 popaw  // the `addr32' (0x67) prefix should have no effect!
+/*
+ *                              now %sp                         INI_SP
+ *                                 ↓                               ↓
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───────┬───────┬───────┬───────┐
+ * │MAGIC7 │MAGIC6 │MAGIC5 │INI_ESP│MAGIC4 │MAGIC3 │MAGIC2 │MAGIC1 │
+ * └───┴───┴───┴───┴───┴───┴───┴───┴───────┴───────┴───────┴───────┘
+ *  %di %si %bp     %bx %dx %cx %ax
+ */
+
+	/* high half of x combined with low half of y */
+#define HL(x, y)	(((x) & ~0xffff) | ((y) & 0xffff))
+
+	cmp	$HL(MAGIC1, MAGIC0),%eax
+	jnz	fail
+	cmp	$HL(MAGIC2, INI_ESP),%ecx
+	jnz	fail
+	cmp	$HL(MAGIC3, MAGIC5 >> 16),%edx
+	jnz	fail
+	cmp	$HL(MAGIC4, MAGIC5),%ebx
+	jnz	fail
+	cmp	$INI_ESP-16,%esp
+	jnz	fail
+	cmp	$HL(MAGIC8, MAGIC6),%ebp
+	jnz	fail
+	cmp	$HL(MAGIC6, MAGIC7 >> 16),%esi
+	jnz	fail
+	cmp	$HL(MAGIC9, MAGIC7),%edi
+	jnz	fail
+
+#define MAGIC10		0x35ff
+#define MAGIC11		0x45de
+#define MAGIC12		0xe0e4
+#define MAGIC13		0x43ab
+#define MAGIC14		0x44819457
+#define MAGIC15		0x92d11944
+#define MAGIC16		0xf5136466
+
+	mov	$MAGIC10,%ax
+	mov	$MAGIC11,%cx
+	mov	$MAGIC12,%dx
+	mov	$MAGIC13,%bx
+	mov	$MAGIC14,%ebp
+	mov	$MAGIC15,%esi
+	mov	$MAGIC16,%edi
+	addr32 pushaw			// `addr32' (0x67) should be ignored
+/*
+ * now %sp                        sp₂                           INI_SP
+ * ↓       +4      +8      +12     ↓                               ↓
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───────┬───────┬───────┬───────┐
+ * │M₁₆│M₁₅│M₁₄│sp₂│M₁₃│M₁₂│M₁₁│M₁₀│MAGIC4 │MAGIC3 │MAGIC2 │MAGIC1 │
+ * └───┴───┴───┴───┴───┴───┴───┴───┴───────┴───────┴───────┴───────┘
+ *  %di %si %bp     %bx %dx %cx %ax
+ */
+
+	mov	%sp,%bp
+	cmpl	$SMUSH(MAGIC10, MAGIC11),12(%bp)
+	jnz	fail
+
+	popal
+/*
+ *                                sp₂                        %sp = INI_SP
+ *                                 ↓                               ↓
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───────┬───────┬───────┬───────┐
+ * │M₁₆│M₁₅│M₁₄│sp₂│M₁₃│M₁₂│M₁₁│M₁₀│MAGIC4 │MAGIC3 │MAGIC2 │MAGIC1 │
+ * └───┴───┴───┴───┴───┴───┴───┴───┴───────┴───────┴───────┴───────┘
+ *  └─────┘ └─────┘ └─────┘          %ebx    %edx    %ecx    %eax
+ *   %edi    %esi    %ebp
+ */
+
+	cmp	$MAGIC1,%eax
+	jnz	fail
+	cmp	$MAGIC2,%ecx
+	jnz	fail
+	cmp	$MAGIC3,%edx
+	jnz	fail
+	cmp	$MAGIC4,%ebx
+	jnz	fail
+	cmp	$INI_ESP,%esp
+	jnz	fail
+	cmp	$SMUSH(MAGIC12, MAGIC13),%ebp
+	jnz	fail
+	cmp	$SMUSH(INI_SP - 16, MAGIC14),%esi
+	jnz	fail
+	cmp	$SMUSH(MAGIC15, MAGIC16),%edi
+	jnz	fail
+
+#define GDT_LEGACY_CODE	8
+#define GDT_LEGACY_DATA	16
+
+	cli
+	lgdtl	good_gdtr
+	mov	%cr0,%eax
+	or	$1,%al
+	mov	%eax,%cr0
+	ljmpw	$GDT_LEGACY_CODE,$2f
+
+fail:
+	int3
+	hlt
+	jmp	fail
+
+	.balign	8
+bad_idt:
+	.quad	0
+
+	.section .text,"ax",@progbits
+
+	.code32
+
+#define PM_ESP		0x00020004	// in 32-bit mode, try starting with
+					// a value of %esp that will force
+					// a carry/borrow in the high half
+					// when we push or pop stuff
+
+2:	mov	$GDT_LEGACY_DATA,%ax
+	mov	%ax,%ds
+	mov	%ax,%es
+	mov	%ax,%ss
+	mov	$PM_ESP,%esp
+
+#define MAGIC17		0xcd2814e8
+#define MAGIC18		0xb7912036
+#define MAGIC19		0xf98a2750
+#define MAGIC20		0x1f6574af
+#define MAGIC21		0xbb4a9d2a
+#define MAGIC22		0x9a86ec5a
+#define MAGIC23		0x33662e67
+
+	mov	$MAGIC17,%eax
+	mov	$MAGIC18,%ecx
+	mov	$MAGIC19,%edx
+	mov	$MAGIC20,%ebx
+	mov	$MAGIC21,%ebp
+	mov	$MAGIC22,%esi
+	mov	$MAGIC23,%edi
+	pushal
+	cmp	$PM_ESP-32,%esp
+	jnz	fail
+
+#define MAGIC24		0xad707a8a
+
+	mov	$MAGIC24,%edi
+	addr16 popaw			// `addr16' (0x67) should be ignored
+/*
+ *                             now %esp                         PM_ESP
+ *                                 ↓                               ↓
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───────┬───────┬───────┬───────┐
+ * │MAGIC23│MAGIC22│MAGIC21│PM_ESP │MAGIC20│MAGIC19│MAGIC18│MAGIC17│
+ * └───┴───┴───┴───┴───┴───┴───┴───┴───────┴───────┴───────┴───────┘
+ *  %di %si %bp     %bx %dx %cx %ax
+ */
+
+	cmpw	$(MAGIC22 >> 16),-10(%esp)
+	jnz	fail
+	cmp	$HL(MAGIC17, PM_ESP >> 16),%eax
+	jnz	fail
+	cmp	$HL(MAGIC18, PM_ESP),%ecx
+	jnz	fail
+	cmp	$HL(MAGIC19, MAGIC21 >> 16),%edx
+	jnz	fail
+	cmp	$HL(MAGIC20, MAGIC21),%ebx
+	jnz	fail
+	cmp	$PM_ESP-16,%esp
+	jnz	fail
+	cmp	$HL(MAGIC21, MAGIC22),%ebp
+	jnz	fail
+	cmp	$HL(MAGIC22, MAGIC23 >> 16),%esi
+	jnz	fail
+	cmp	$HL(MAGIC24, MAGIC23),%edi
+	jnz	fail
+
+#define MAGIC25		0x205de5bd
+
+	mov	$MAGIC25,%eax
+	popaw
+/*
+ *                                                             now %esp =
+ *                                                              PM_ESP
+ *                                                                 ↓
+ * ┌───────┬───────┬───────┬───────┬───┬───┬───┬───┬───┬───┬───┬───┐
+ * │MAGIC23│MAGIC22│MAGIC21│PM_ESP │MAGIC20│MAGIC19│MAGIC18│MAGIC17│
+ * └───────┴───────┴───────┴───────┴───┴───┴───┴───┴───┴───┴───┴───┘
+ *                                  %di %si %bp     %bx %dx %cx %ax
+ */
+	cmpw	$(MAGIC19 >> 16),-10(%esp)
+	jnz	fail
+	cmp	$HL(MAGIC25, MAGIC17 >> 16),%eax
+	jnz	fail
+	cmp	$HL(MAGIC18, MAGIC17),%ecx
+	jnz	fail
+	cmp	$HL(MAGIC19, MAGIC18 >> 16),%edx
+	jnz	fail
+	cmp	$HL(MAGIC20, MAGIC18),%ebx
+	jnz	fail
+	cmp	$PM_ESP,%esp
+	jnz	fail
+	cmp	$HL(MAGIC21, MAGIC19),%ebp
+	jnz	fail
+	cmp	$HL(MAGIC22, MAGIC20 >> 16),%esi
+	jnz	fail
+	cmp	$HL(MAGIC24, MAGIC20),%edi
+	jnz	fail
+
+	cli				// tests passed
+	xor	%edi,%edi
+	lidt	bad_idt
+	mov	$231,%eax
+	syscall				// this will triple fault on a real PC
+
+	.section .rodata,"a",@progbits
+
+good_gdtr:
+	.short	good_gdt_end-good_gdt-1
+	.long	good_gdt
+
+	.balign	8
+
+good_gdt:
+.quad	0b0000000000000000000000000000000000000000000000000000000000000000 # 0
+.quad	0b0000000011001111100110100000000000000000000000001111111111111111 # 8
+.quad	0b0000000011001111100100100000000000000000000000001111111111111111 #16
+good_gdt_end:


### PR DESCRIPTION
* Implement `clts` (clear task-switched flag) instruction
* Partly implement `enter` (make stack frame) instruction, for nesting level = 0
* Fix operand size handling for `leave`, `pusha`, and `popa` instructions
* Disassemble (but not yet execute) `sldt`, `str`, `lldt`, `ltr`, `verr`, and `verw` instructions (https://github.com/tkchia/blink/commit/00d8ba089453943ef8e3e25b8c38fe84c43de2ae)