### PR TITLE
Tweak handling of guest machine execution mode

### DIFF
--- a/blink/address.c
+++ b/blink/address.c
@@ -29,7 +29,7 @@ i64 GetPc(struct Machine *m) {
 }
 
 i64 GetIp(struct Machine *m) {
-  return MaskAddress(m->mode, m->ip);
+  return MaskAddress(m->mode.omode, m->ip);
 }
 
 u64 MaskAddress(u32 mode, u64 x) {

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -207,7 +207,7 @@ static int Exec(char *execfn, char *prog, char **argv, char **envp) {
   sigset_t oldmask;
   struct Machine *m, *old;
   if ((old = g_machine)) KillOtherThreads(old->system);
-  unassert((g_machine = m = NewMachine(NewSystem(XED_MODE_LONG), 0)));
+  unassert((g_machine = m = NewMachine(NewSystem(XED_MACHINE_MODE_LONG), 0)));
 #ifdef HAVE_JIT
   if (FLAG_nojit) DisableJit(&m->system->jit);
 #endif

--- a/blink/dis.c
+++ b/blink/dis.c
@@ -241,7 +241,7 @@ static long DisAppendOpLines(struct Dis *d, struct Machine *m, i64 addr) {
       n = k;
     }
   }
-  DecodeInstruction(d->xedd, p, n, m->mode);
+  DecodeInstruction(d->xedd, p, n, m->mode.omode);
   n = d->xedd->length;
   op.addr = addr;
   op.size = n;

--- a/blink/fpu.c
+++ b/blink/fpu.c
@@ -1030,7 +1030,7 @@ void OpFpu(P) {
   bool ismemory;
   op = Opcode(rde) & 7;
   ismemory = ModrmMod(rde) != 3;
-  m->fpu.ip = MaskAddress(m->mode, m->ip - Oplength(rde));
+  m->fpu.ip = MaskAddress(m->mode.omode, m->ip - Oplength(rde));
   m->fpu.op = op << 8 | ModrmMod(rde) << 6 | ModrmReg(rde) << 3 | ModrmRm(rde);
   m->fpu.dp = ismemory ? ComputeAddress(A) : 0;
   switch (DISP(op, ismemory, ModrmReg(rde))) {

--- a/blink/instruction.c
+++ b/blink/instruction.c
@@ -46,7 +46,7 @@ static bool IsOpcodeEqual(struct XedDecodedInst *xedd, u8 *a) {
 static int ReadInstruction(struct Machine *m, u8 *p, unsigned n) {
   struct XedDecodedInst xedd[1];
   STATISTIC(++instructions_decoded);
-  if (!DecodeInstruction(xedd, p, n, m->mode)) {
+  if (!DecodeInstruction(xedd, p, n, m->mode.omode)) {
     memcpy(m->xedd, xedd, kInstructionBytes);
     return 0;
   } else {

--- a/blink/loader.c
+++ b/blink/loader.c
@@ -746,7 +746,7 @@ error: unsupported executable; we need:\n\
     m->system->brk ^= Read64(elf->rng) & FLAG_aslrmask;
     m->system->automap ^= (Read64(elf->rng) & FLAG_aslrmask);
   }
-  if (m->mode == XED_MODE_REAL) {
+  if (m->mode.genmode == XED_GEN_MODE_REAL) {
     LoadDefaultBios(m);
     if (endswith(prog, ".com")) {
       // cosmo convention (see also binbase)

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -215,7 +215,7 @@ static relegated void OpLsl(P) {
   }
 }
 
-void SetMachineMode(struct Machine *m, int mode) {
+void SetMachineMode(struct Machine *m, struct XedMachineMode mode) {
   m->mode = mode;
   m->system->mode = mode;
 }
@@ -810,11 +810,11 @@ static void GenInterrupt(P, u8 trapno) {
 #else
   u16 offset;
   struct System *s;
-  switch (m->mode) {
+  switch (m->mode.genmode) {
     default:
       HaltMachine(m, trapno);
       break;
-    case XED_MODE_REAL:
+    case XED_GEN_MODE_REAL:
       offset = (u16)trapno * 4;
       s = m->system;
       if (offset + 3 > s->idt_limit) {
@@ -872,7 +872,7 @@ static void OpInterrupt3(P) {
 
 #ifndef DISABLE_METAL
 static void OpInto(P) {
-  if (m->mode != XED_MODE_LONG) {
+  if (Mode(rde) != XED_MODE_LONG) {
     if (GetFlag(m->flags, FLAGS_OF)) HaltMachine(m, 4);
   } else {
     OpUdImpl(m);
@@ -880,7 +880,7 @@ static void OpInto(P) {
 }
 
 static void OpIret(P) {
-  if (m->mode == XED_MODE_REAL) {
+  if (m->mode.genmode == XED_GEN_MODE_REAL) {
     OpRetf(A);
     if (!Osz(rde)) {
       // Intel V2A § 3.2 says that iretl should only update some parts of

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -248,7 +248,7 @@ struct OpCache {
 };
 
 struct System {
-  u8 mode;
+  struct XedMachineMode mode;
   bool dlab;
   bool isfork;
   bool exited;
@@ -326,7 +326,7 @@ struct MachineTlb {
 struct Machine {                         //
   u64 ip;                                // instruction pointer
   u8 oplen;                              // length of operation
-  u8 mode;                               // [dup] XED_MODE_{REAL,LEGACY,LONG}
+  struct XedMachineMode mode;            // [dup] XED_MACHINE_MODE_REAL etc.
   bool threaded;                         // must use synchronization
   _Atomic(bool) attention;               // signals main interpreter loop
   u32 flags;                             // x86 eflags register
@@ -441,10 +441,10 @@ extern _Thread_local struct Machine *g_machine;
 extern const nexgen32e_f kConvert[3];
 extern const nexgen32e_f kSax[3];
 
-struct System *NewSystem(int);
+struct System *NewSystem(struct XedMachineMode);
 void FreeSystem(struct System *);
 void SignalActor(struct Machine *);
-void SetMachineMode(struct Machine *, int);
+void SetMachineMode(struct Machine *, struct XedMachineMode);
 struct Machine *NewMachine(struct System *, struct Machine *);
 i64 AreAllPagesUnlocked(struct System *) nosideeffect;
 bool IsOrphan(struct Machine *) nosideeffect;
@@ -802,7 +802,7 @@ void LogCodOp(struct Machine *, const char *);
 #endif
 
 MICRO_OP_SAFE u8 Cpl(struct Machine *m) {
-  return m->mode != XED_MODE_REAL ? (m->cs.sel & 3u) : 0u;
+  return m->mode.genmode != XED_GEN_MODE_REAL ? (m->cs.sel & 3u) : 0u;
 }
 
 #define BEGIN_NO_PAGE_FAULTS \

--- a/blink/memory.c
+++ b/blink/memory.c
@@ -262,8 +262,8 @@ MapError:
 u8 *LookupAddress2(struct Machine *m, i64 virt, u64 mask, u64 need) {
   u8 *host;
   u64 entry;
-  if (m->mode == XED_MODE_LONG ||
-      (m->mode != XED_MODE_REAL && (m->system->cr0 & CR0_PG))) {
+  if (m->mode.omode == XED_MODE_LONG ||
+      (m->mode.genmode != XED_GEN_MODE_REAL && (m->system->cr0 & CR0_PG))) {
     if (!(entry = FindPageTableEntry(m, virt & -4096))) {
       return 0;
     }
@@ -316,7 +316,7 @@ bool IsValidMemory(struct Machine *m, i64 virt, i64 size, int prot) {
   u64 pte, mask, need;
   size += virt & 4095;
   virt &= -4096;
-  unassert(m->mode == XED_MODE_LONG);
+  unassert(m->mode.omode == XED_MODE_LONG);
   unassert(prot && !(prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC)));
   need = mask = 0;
   if (prot & PROT_READ) {

--- a/blink/memorymalloc.c
+++ b/blink/memorymalloc.c
@@ -189,19 +189,21 @@ long GetMaxRss(struct System *s) {
   return MIN(kMaxResident, Read64(s->rlim[RLIMIT_AS_LINUX].cur)) / 4096;
 }
 
-struct System *NewSystem(int mode) {
+struct System *NewSystem(struct XedMachineMode mode) {
   long i;
   struct System *s;
-  unassert(mode == XED_MODE_REAL ||    //
-           mode == XED_MODE_LEGACY ||  //
-           mode == XED_MODE_LONG);
+  unassert(mode.omode == XED_MODE_REAL ||    //
+           mode.omode == XED_MODE_LEGACY ||  //
+           mode.omode == XED_MODE_LONG);
+  unassert(mode.genmode == XED_GEN_MODE_REAL ||    //
+           mode.genmode == XED_GEN_MODE_PROTECTED);
   if (posix_memalign((void **)&s, _Alignof(struct System), sizeof(*s))) {
     enomem();
     return 0;
   }
   memset(s, 0, sizeof(*s));
   s->mode = mode;
-  if (s->mode == XED_MODE_REAL) {
+  if (s->mode.omode == XED_MODE_REAL) {
     if (posix_memalign((void **)&s->real, 4096, kRealSize)) {
       free(s);
       enomem();
@@ -787,7 +789,7 @@ i64 ReserveVirtual(struct System *s, i64 virt, i64 size, u64 flags, int fd,
   unassert(!(flags & PAGE_MAP));
   unassert(!(flags & PAGE_HOST));
   unassert(!(flags & PAGE_RSRV));
-  unassert(s->mode == XED_MODE_LONG);
+  unassert(s->mode.omode == XED_MODE_LONG);
 
   // determine memory protection
   prot = GetProtection(flags);

--- a/blink/op101.c
+++ b/blink/op101.c
@@ -32,7 +32,7 @@ static void StoreDescriptorTable(P, u16 limit, u64 base) {
   l = ComputeAddress(A);
   if (l + 10 <= kRealSize) {
     Write16(m->system->real + l, limit);
-    if (m->mode == XED_MODE_LONG) {
+    if (Mode(rde) == XED_MODE_LONG) {
       Write64(m->system->real + l + 2, base);
       SetWriteAddr(m, l, 10);
     } else {
@@ -56,7 +56,7 @@ static void LoadDescriptorTable(P, u16 *out_limit, u64 *out_base) {
     //   loaded."
     // - "In 64-bit mode, the instruction’s operand size is fixed at 8 + 2
     //   bytes (an 8-byte base and a 2-byte limit)."
-    if (m->mode == XED_MODE_LONG) {
+    if (Mode(rde) == XED_MODE_LONG) {
       base = Read64(m->system->real + l + 2);
       SetReadAddr(m, l, 10);
     } else if (!Osz(rde)) {
@@ -116,7 +116,7 @@ static void InvlpgM(P) {
   // if (Cpl(m)) OpUdImpl(m);
   as = LoadEffectiveAddress(A);
   virt = as.seg + as.addr;
-  if (m->mode == XED_MODE_LONG &&
+  if (Mode(rde) == XED_MODE_LONG &&
       !(-0x800000000000 <= virt && virt < 0x800000000000)) {
     // In 64-bit mode, if the memory address is in non-canonical form,
     // then INVLPG is the same as a NOP. -Quoth Intel §invlpg

--- a/blink/pml4t.c
+++ b/blink/pml4t.c
@@ -57,7 +57,7 @@ int FindContiguousMemoryRanges(struct Machine *m,
                                struct ContiguousMemoryRanges *ranges) {
   u64 cr3;
   ranges->i = 0;
-  if (m->mode == XED_MODE_LONG) {
+  if (m->mode.omode == XED_MODE_LONG) {
     cr3 = m->system->cr3;
     FindContiguousMemoryRangesImpl(m, ranges, 0, 39, cr3, 256, 512);
     FindContiguousMemoryRangesImpl(m, ranges, 0, 39, cr3, 0, 256);

--- a/blink/pml4tfmt.c
+++ b/blink/pml4tfmt.c
@@ -214,7 +214,7 @@ char *FormatPml4t(struct Machine *m) {
   struct MapMaker u = {.b = b};
   u16 range[][2] = {{256, 512}, {0, 256}};
   b[0] = 0;
-  if (m->mode != XED_MODE_LONG) return b;
+  if (m->mode.omode != XED_MODE_LONG) return b;
   unassert(m->system->cr3);
   pd[0] = GetPt(m, m->system->cr3, true);
   for (i = 0; i < ARRAYLEN(range); ++i) {

--- a/blink/x86.h
+++ b/blink/x86.h
@@ -29,6 +29,30 @@
 #define XED_ILD_MAP6    6
 #define XED_ILD_BAD_MAP 7
 
+#define XED_GEN_MODE_REAL      0
+#define XED_GEN_MODE_PROTECTED 1
+#define XED_GEN_MODE_V86       2  // unimplemented
+
+struct XedMachineMode {
+  uint8_t omode : 2,    // bitness of operands, for instruction decoding
+                        // - 16-bit if XED_MODE_REAL
+                        // - 32-bit if XED_MODE_LEGACY
+                        // - 64-bit if XED_MODE_LONG
+          genmode : 6;  // general machine mode
+                        // - real address mode if XED_GEN_MODE_REAL
+                        // - protected/long mode, with GDT & all that, if
+                        //   XED_GEN_MODE_PROTECTED
+};
+
+#define XED_MACHINE_MODE_REAL \
+        ((struct XedMachineMode){XED_MODE_REAL, XED_GEN_MODE_REAL})
+#define XED_MACHINE_MODE_LEGACY_16 \
+        ((struct XedMachineMode){XED_MODE_REAL, XED_GEN_MODE_PROTECTED})
+#define XED_MACHINE_MODE_LEGACY_32 \
+        ((struct XedMachineMode){XED_MODE_LEGACY, XED_GEN_MODE_PROTECTED})
+#define XED_MACHINE_MODE_LONG \
+        ((struct XedMachineMode){XED_MODE_LONG, XED_GEN_MODE_PROTECTED})
+
 #define XED_MAX_INSTRUCTION_BYTES 15
 
 #define XED_ERROR_NONE              0

--- a/test/blink/modrm_test.c
+++ b/test/blink/modrm_test.c
@@ -30,7 +30,7 @@ struct XedDecodedInst xedd;
 
 void SetUp(void) {
   InitMap();
-  unassert((s = NewSystem(XED_MODE_LONG)));
+  unassert((s = NewSystem(XED_MACHINE_MODE_LONG)));
   unassert((m = NewMachine(s, 0)));
   m->xedd = &xedd;
   memset(&xedd, 0, sizeof(xedd));


### PR DESCRIPTION
- Split machine mode `m->mode` into two parts, to explicitly distinguish real mode & 16-bit protected mode
  - `m->mode.omode` now says how instructions should be decoded
  - `m->mode.genmode` says whether guest is in real mode or not
- Use `Mode(rde)` more often, so we can optimize away dead code on `--disable-metal`
- Setting `CR0_PE` in guest `%cr0` now immediately triggers machine mode change