### PR TITLE
Gracefully handle end of disk images in bare metal `int 0x13`

### DIFF
--- a/blink/loader.c
+++ b/blink/loader.c
@@ -487,7 +487,7 @@ void BootProgram(struct Machine *m,  //
   memset(m->system->real + 0x500, 0, kBiosBase - 0x500);
   memset(m->system->real + 0x00100000, 0, kRealSize - 0x00100000);
   if ((fd = VfsOpen(AT_FDCWD, m->system->elf.prog, O_RDONLY, 0)) == -1 ||
-      VfsRead(fd, m->system->real + 0x7c00, 512) != 512) {
+      VfsRead(fd, m->system->real + 0x7c00, 512) <= 0) {
     // if we failed to load the boot sector for whatever reason, then...
     // ...arrange to invoke int 0x18 (diskless boot hook)
     // TODO: maybe error out more quickly?


### PR DESCRIPTION
- If image file size is not a multiple of the sector size (512 bytes), treat it as being padded with zeros up to a sector boundary
- If, after padding, the sector count during a read is still short, then return the number of sectors successfully read rather than just saying 0