### PR TITLE
Implement more BIOS functionality in Blinkenlights metal mode

### DIFF
--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -444,6 +444,9 @@ static int diskcyls = 1023;
 static int diskheads = 16;  // default to 16 heads/cylinder, following QEMU
 static int disksects = 63;
 
+static u64 prevday = 0;  // day number of last call to int 0x1A, ah = 0, for
+                         // calculating elapsed midnight count
+
 static char *xasprintf(const char *fmt, ...) {
   char *s;
   va_list va;
@@ -2972,6 +2975,28 @@ static void OnVidyaService(void) {
   }
 }
 
+static void OnSerialServiceReset(void) {
+  if (Get16(m->dx) == 0) {
+    m->al = 0xb0;  // following QEMU
+    m->ah = 0x60;
+  } else {
+    m->al = 0x00;  // Ralf Brown's Interrupt List says "AX = 9E00h if
+    m->ah = 0x9e;  // disconnected (ArtiCom)"
+  }
+}
+
+static void OnSerialService(void) {
+  switch (m->ah) {
+    case 0x00:
+      OnSerialServiceReset();
+      break;
+    default:
+      m->al = 0x00;
+      m->ah = 0x9e;
+      break;
+  }
+}
+
 static void OnKeyboardServiceReadKeyPress(void) {
   uint8_t b;
   ssize_t rc;
@@ -3078,6 +3103,83 @@ static void OnBaseMemSizeService(void) {
   Put16(m->ax, Get16(m->system->real + 0x413));
 }
 
+static void OnTimeServiceGetSystemTime(void) {
+  u64 DAY_SECS = 24UL * 60 * 60;
+  struct timespec now = GetTime();
+  u64 currday, daytime;
+  u8 midnights = 0;
+  unassert(now.tv_sec >= DAY_SECS);
+  currday = (u64)now.tv_sec / DAY_SECS;
+  // calculate the number of midnights elapsed since the last call here
+  // this will also reset the midnight count
+  if (prevday != 0) {
+    if (currday > prevday) midnights = currday - prevday;
+  }
+  prevday = currday;
+  // calculate nanoseconds from day start
+  daytime = (u64)now.tv_sec - currday * DAY_SECS;
+  daytime = daytime * 1000000000L + now.tv_nsec;
+  // calculate BIOS system timer ticks from day start
+  daytime = daytime * (0x1800B0L / 80) / (DAY_SECS * 1000000000L / 80);
+  Put16(m->cx, daytime >> 16);
+  Put16(m->dx, daytime);
+  m->al = midnights;
+}
+
+static u8 ToBcdByte(u8 binary) {
+  static const u8 bcd[] =
+    {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+     0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
+     0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
+     0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
+     0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,
+     0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
+     0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
+     0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
+     0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99};
+  unassert(binary <= 99);
+  return bcd[binary];
+}
+
+static void OnTimeServiceGetRtcTime(void) {
+  struct timespec now = GetTime();
+  struct tm tm;
+  unassert(gmtime_r(&now.tv_sec, &tm));
+  m->ch = ToBcdByte(tm.tm_hour);
+  m->cl = ToBcdByte(tm.tm_min);
+  m->dh = ToBcdByte(tm.tm_sec);
+  m->dl = tm.tm_isdst;
+  SetCarry(false);
+}
+
+static void OnTimeServiceGetRtcDate(void) {
+  struct timespec now = GetTime();
+  struct tm tm;
+  unassert(gmtime_r(&now.tv_sec, &tm));
+  m->ch = ToBcdByte((tm.tm_year / 100U + 19) % 100U);
+  m->cl = ToBcdByte(tm.tm_year % 100U);
+  m->dh = ToBcdByte(tm.tm_mon + 1U);
+  m->dl = ToBcdByte(tm.tm_mday);
+  SetCarry(false);
+}
+
+static void OnTimeService(void) {
+  switch (m->ah) {
+    case 0x00:
+      OnTimeServiceGetSystemTime();
+      break;
+    case 0x02:
+      OnTimeServiceGetRtcTime();
+      break;
+    case 0x04:
+      OnTimeServiceGetRtcDate();
+      break;
+    default:
+      SetCarry(true);
+  }
+}
+
 static bool OnHalt(int interrupt) {
   SYS_LOGF("%" PRIx64 " %s OnHalt(%#x)", GetPc(m), tuimode ? "TUI" : "EXEC",
            interrupt);
@@ -3094,6 +3196,9 @@ static bool OnHalt(int interrupt) {
     case 0x10:
       OnVidyaService();
       return true;
+    case 0x14:
+      OnSerialService();
+      return true;
     case 0x15:
       OnInt15h();
       return true;
@@ -3108,6 +3213,9 @@ static bool OnHalt(int interrupt) {
       return true;
     case 0x19:
       BootProgram(m, &m->system->elf);
+      return true;
+    case 0x1A:
+      OnTimeService();
       return true;
     case kMachineEscape:
       return true;

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -3103,6 +3103,10 @@ static void OnBaseMemSizeService(void) {
   Put16(m->ax, Get16(m->system->real + 0x413));
 }
 
+static void OnPrinterService(void) {
+  m->ah = 0xb0;  // "no printer": not busy, out of paper, selected
+}
+
 static void OnTimeServiceGetSystemTime(void) {
   u64 DAY_SECS = 24UL * 60 * 60;
   struct timespec now = GetTime();
@@ -3210,6 +3214,9 @@ static bool OnHalt(int interrupt) {
       return true;
     case 0x12:
       OnBaseMemSizeService();
+      return true;
+    case 0x17:
+      OnPrinterService();
       return true;
     case 0x19:
       BootProgram(m, &m->system->elf);

--- a/test/metal/biostime.S
+++ b/test/metal/biostime.S
@@ -1,0 +1,100 @@
+#include "test/metal/mac.inc"
+
+	.section .head,"ax",@progbits
+	.code16
+
+.globl	_start
+_start:
+
+//	make -j8 o//blink o//test/metal/biostime.bin
+//	o//blink/blinkenlights -r o//test/metal/biostime.bin
+
+	ljmpw	$0,$1f
+1:
+	.test	"real time clock should not move much slower than system clock"
+	mov	$5,%bp
+2:
+	mov	$2,%ah			// get starting RTC time
+	int	$0x1a
+	.nc
+	mov	%cl,%dl
+	mov	%dx,%si
+	mov	$0,%ah			// get starting system time
+	int	$0x1a
+	push	%cx
+	push	%dx
+	pop	%edi
+3:
+	mov	$0,%ah			// wait until at least 20 system clock
+	int	$0x1a			// ticks (slightly more than 1s)
+	push	%cx			// have elapsed
+	push	%dx
+	pop	%edx
+	cmp	$0x1800b0,%edx
+	.c
+	sub	%edi,%edx
+	jnc	4f
+	add	$0x1800b0,%edx
+4:
+	cmp	$20,%edx
+	jb	3b
+	cmp	$0x1800b0/2,%edx
+	ja	1b			// lolwut?
+	mov	$2,%ah			// get new RTC time
+	int	$0x1a
+	.nc
+	mov	%cl,%dl
+	cmp	%dx,%si			// RTC time should have changed by now
+	.nz
+	dec	%bp			// retry this 5 times
+	jnz	2b
+
+	.test	"system clock should not move much slower than real time clock"
+5:
+	mov	$2,%ah			// wait until RTC time rolls over
+	int	$0x1a			// to next second
+	.nc
+	mov	%cl,%dl
+	mov	%dx,%si
+6:
+	mov	$2,%ah
+	int	$0x1a
+	mov	%cl,%dl
+	cmp	%dx,%si
+	je	6b
+	mov	$5,%bp
+7:
+	mov	$0,%ah			// get starting system time
+	int	$0x1a
+	push	%cx
+	push	%dx
+	pop	%edi
+	mov	$2,%ah			// get starting RTC time
+	int	$0x1a
+	.nc
+	mov	%cl,%dl
+	mov	%dx,%si
+8:
+	mov	$2,%ah			// wait until RTC time rolls over
+	int	$0x1a			// to next second
+	.nc
+	mov	%cl,%dl
+	cmp	%dx,%si
+	jz	8b
+	mov	$0,%ah			// system time should have advanced
+	int	$0x1a			// by at least 16 ticks by now
+	push	%cx
+	push	%dx
+	pop	%edx
+	sub	%edi,%edx
+	jnc	9f
+	add	$0x1800b0,%edx
+9:
+	cmp	$16,%edx
+	.nc
+	cmp	$0x1800b0/2,%edx
+	ja	5b
+	dec	%bp
+	jnz	7b
+
+	.exit


### PR DESCRIPTION
- `int 0x14`
  - `%ah` = 0 (initialize serial port)
- `int 0x1a`
  - `%ah` = 0 (get system time)
  - `%ah` = 2 (get real time clock time)
  - `%ah` = 4 (get real time clock date)
- `int 0x17`
  - `%ah` = 0, 1, 2 (write printer character; initialize printer port; get printer status)