### PR TITLE
Various minor changes

### DIFF
--- a/blink/defbios.c
+++ b/blink/defbios.c
@@ -115,9 +115,9 @@ static const u8 defbios[] = {
 void LoadDefaultBios(struct Machine *m) {
   size_t kBiosSize = sizeof(defbios);
   memcpy(m->system->real + kBiosEnd - kBiosSize, defbios, kBiosSize);
-  m->cs.sel = kBiosEntry >> 4;
-  m->cs.base = kBiosEntry;
-  m->ip = 0;
+  m->cs.sel = kBiosSeg;
+  m->cs.base = kBiosBase;
+  m->ip = kBiosEntry - kBiosBase;
 }
 
 void SetDefaultBiosIntVectors(struct Machine *m) {

--- a/blink/loader.c
+++ b/blink/loader.c
@@ -297,8 +297,11 @@ static void ExplainWhyItCantBeEmulated(const char *path, const char *reason) {
 
 static bool IsBinFile(const char *prog) {
   return endswith(prog, ".bin") ||  //
+         endswith(prog, ".BIN") ||  //
          endswith(prog, ".img") ||  //
-         endswith(prog, ".raw");
+         endswith(prog, ".IMG") ||  //
+         endswith(prog, ".raw") ||  //
+         endswith(prog, ".RAW");
 }
 
 bool IsSupportedExecutable(const char *path, void *image, size_t size) {
@@ -748,7 +751,8 @@ error: unsupported executable; we need:\n\
   }
   if (m->mode.genmode == XED_GEN_MODE_REAL) {
     LoadDefaultBios(m);
-    if (endswith(prog, ".com")) {
+    if (endswith(prog, ".com") ||  //
+        endswith(prog, ".COM")) {
       // cosmo convention (see also binbase)
       AddFileMap(m->system, 4 * 1024 * 1024, 512, prog, 0);
     } else {


### PR DESCRIPTION
* Recognize upper case `.BIN`, `.IMG`, `.RAW`, & `.COM` file extensions
* Improve display of segment registers
* Use `0xF000:0xFFF0`, not `0xFFFF:0`, as metal mode entry point