### PR TITLE
Upstream blink16 TUI enhancements & add BIOS video ram support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ MAKEFILES =				\
 
 $(OBJS): $(MAKEFILES)
 
-xDEPENDS =				\
+DEPENDS =				\
 	o/$(MODE)/depend.host		\
 	o/$(MODE)/depend.i486		\
 	o/$(MODE)/depend.m68k		\

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ MAKEFILES =				\
 
 $(OBJS): $(MAKEFILES)
 
-DEPENDS =				\
+xDEPENDS =				\
 	o/$(MODE)/depend.host		\
 	o/$(MODE)/depend.i486		\
 	o/$(MODE)/depend.m68k		\

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -1384,7 +1384,7 @@ static void DrawDisplay(struct Panel *p) {
   switch (vidya) {
     case 7:     // MDA 80x25 4-gray
       DrawHr(&pan.displayhr, "MONOCHROME DISPLAY ADAPTER");
-      DrawMda(p, (u8(*)[80][2])(m->system->real + 0xb0000));
+      DrawMda(p, (u8(*)[80][2])(m->system->real + 0xb0000), pty->x, pty->y);
       break;
     case 2:     // CGA 80x25 16-gray
       DrawHr(&pan.displayhr, "COLOR GRAPHICS ADAPTER");
@@ -2931,8 +2931,6 @@ static void VidyaServiceScrollUp(int y1, int y2, unsigned char attr) {
 static void VidyaServiceWriteVideoRam(void) {
   u16 *vram;
   switch (m->al) {
-  case '\a':
-    return;
   case '\b':
     if (--pty->x <= 0) {
       pty->x = 0;
@@ -2943,6 +2941,9 @@ static void VidyaServiceWriteVideoRam(void) {
     return;
   case '\n':
     goto scroll;
+  case '\0':
+  case '\a':
+    return;
   }
   vram = (u16 *)video_ram();
   vram[page_offsetw() + pty->y * pty->xn + pty->x] = m->al | (m->bl << 8);

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -2271,8 +2271,8 @@ static void HandleAppReadInterrupt(void) {
     if (action & CONTINUE) {
       action &= ~CONTINUE;
     } else {
-      LeaveScreen();
-      exit(0);
+      tuimode = true;
+      displayexec = false;
     }
   }
 }
@@ -3131,6 +3131,7 @@ static void OnKeyboardServiceReadKeyPress(void) {
     if (rc > 0) {
       pending = rc;
     } else if (rc == -1 && errno == EINTR) {
+      HandleAppReadInterrupt();
       return;
     } else {
       exitcode = 0;

--- a/blink/cga.c
+++ b/blink/cga.c
@@ -17,6 +17,7 @@
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include <stdio.h>
+#include <termios.h>
 
 #include "blink/buffer.h"
 #include "blink/cga.h"
@@ -47,8 +48,13 @@ void DrawCga(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
     a = -1;
     for (x = 0; x < 80; ++x) {
       if (x == curx && y == cury) {
-        AppendData(&p->lines[y], buf, FormatCga(0x07, buf));
-        AppendWide(&p->lines[y], CURSOR);
+        if (v[y][x][0] == ' ' || v[y][x][0] == '\0') {
+          AppendData(&p->lines[y], buf, FormatCga(a = 0x07, buf));
+          AppendWide(&p->lines[y], CURSOR);
+        } else {
+          AppendData(&p->lines[y], buf, FormatCga(a = 0x70, buf));
+          AppendWide(&p->lines[y], kCp437[v[y][x][0]]);
+        }
       } else {
         if (v[y][x][1] != a) {
           AppendData(&p->lines[y], buf, FormatCga((a = v[y][x][1]), buf));

--- a/blink/cga.c
+++ b/blink/cga.c
@@ -42,25 +42,29 @@ size_t FormatCga(u8 bgfg, char buf[11]) {
 
 void DrawCga(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
   char buf[11];
-  unsigned y, x, n, a;
+  unsigned y, x, n, a, ch, attr;
   n = MIN(25, p->bottom - p->top);
   for (y = 0; y < n; ++y) {
     a = -1;
     for (x = 0; x < 80; ++x) {
+      ch = v[y][x][0];
+      attr = v[y][x][1];
       if (x == curx && y == cury) {
-        if (v[y][x][0] == ' ' || v[y][x][0] == '\0') {
-          AppendData(&p->lines[y], buf, FormatCga(a = 0x07, buf));
-          AppendWide(&p->lines[y], CURSOR);
+        if (ch == ' ' || ch == '\0') {
+          ch = CURSOR;
+          attr = 0x07;
         } else {
-          AppendData(&p->lines[y], buf, FormatCga(a = 0x70, buf));
-          AppendWide(&p->lines[y], kCp437[v[y][x][0]]);
+          ch = kCp437[ch];
+          attr = 0x70;
         }
+        a = -1;
       } else {
-        if (v[y][x][1] != a) {
-          AppendData(&p->lines[y], buf, FormatCga((a = v[y][x][1]), buf));
-        }
-        AppendWide(&p->lines[y], kCp437[v[y][x][0]]);
+        ch = kCp437[ch];
       }
+      if (attr != a) {
+        AppendData(&p->lines[y], buf, FormatCga((a = attr), buf));
+      }
+      AppendWide(&p->lines[y], ch);
     }
     AppendStr(&p->lines[y], "\033[0m");
   }

--- a/blink/cga.h
+++ b/blink/cga.h
@@ -3,7 +3,7 @@
 #include "blink/panel.h"
 #include "blink/types.h"
 
-void DrawCga(struct Panel *, u8[25][80][2]);
+void DrawCga(struct Panel *, u8[25][80][2], int, int);
 size_t FormatCga(u8, char[11]);
 
 #endif /* BLINK_CGA_H_ */

--- a/blink/high.c
+++ b/blink/high.c
@@ -25,7 +25,11 @@
 struct High g_high = {
     .enabled = true,
     .active = true,
+#ifdef __APPLE__
+    .keyword = 40,
+#else
     .keyword = 155,
+#endif
     .reg = 215,
     .literal = 182,
     .label = 221,

--- a/blink/ioports.c
+++ b/blink/ioports.c
@@ -99,6 +99,8 @@ static int OpSerialIn(struct Machine *m, int r) {
       if (p & POLLIN) s |= UART_TTYDA;
       if (p & POLLOUT) s |= UART_TTYTXR;
       return s;
+    case UART_DLM:
+      return -1;
     default:
       return 0;
   }

--- a/blink/mda.c
+++ b/blink/mda.c
@@ -62,6 +62,8 @@ void DrawMda(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
           attr = 0x70;
         }
         a = -1;
+      } else {
+        ch = kCp437[ch];
       }
       b = DecodeMdaAttributes(attr);
       if (a != b) {
@@ -73,11 +75,7 @@ void DrawMda(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
         if (a & kReverse) AppendStr(&p->lines[y], ";7");
         AppendChar(&p->lines[y], 'm');
       }
-      if (a) {
-        AppendWide(&p->lines[y], ch);
-      } else {
-        AppendChar(&p->lines[y], ' ');
-      }
+      AppendWide(&p->lines[y], ch);
     }
   }
 }

--- a/blink/mda.h
+++ b/blink/mda.h
@@ -4,6 +4,6 @@
 
 #include "blink/panel.h"
 
-void DrawMda(struct Panel *, u8[25][80][2]);
+void DrawMda(struct Panel *, u8[25][80][2], int, int);
 
 #endif /* BLINK_MDA_H_ */

--- a/blink/pty.c
+++ b/blink/pty.c
@@ -1458,7 +1458,8 @@ char *PtyEncodeStyle(char *p, u32 xr, u32 pr, u32 fg, u32 bg) {
 int PtyAppendLine(struct Pty *pty, struct Buffer *buf, unsigned y) {
   u64 u;
   char *p, *pb;
-  u32 i, j, n, w, wc, np, xp, pr, fg, bg, ci;
+  u32 i, j, n, wc, np, xp, pr, fg, bg, ci;
+  int w;
   if (y >= pty->yn) {
     errno = EINVAL;
     return -1;


### PR DESCRIPTION
This PR sends various `blink16` enhancements upstream to `blink`.

Fixes TUI behavior when mixing c)ontinue and C)ontinue harder TUI commands.

Adds D)isplay only command for fast display of pty/teletypewriter output only. (Just like C but only pty panel, ^C to stop. Very useful for much faster boot of operating systems before starting a debug session).

Draws pty output and accepts pty input during C)ontinue and D)isplay commands.

Adds `int 0x16` AH=1 check keypress BIOS function.

There remains a bit of funkiness having to do with the `setitimer` real time timer and ALARM status line redraw callbacks during C) and D) execution, still perfecting that.

With these changes, `blink` can now boot and run both the [ELKS](https://github.com/jbruchon/elks) kernel and [FreeDOS](https://www.freedos.org/download/) v1.3 in real mode. (These are the `fd1440.img` and `freedos13.img` over at [blink16](https://github.com/ghaerr/blink16)).

Here's `blink` booting ELKS: 
![blink booting ELKS](https://user-images.githubusercontent.com/11985637/234748139-7f3a89dd-5375-4cec-b697-04f4861254cb.png)
(Note: the ELKS bioshd retries and errors are the result of `blink` not yet implementing `int 0x13` AH=3 Write Sectors.

Here's the same ELKS boot running in D)isplay only mode:
![blink D command](https://user-images.githubusercontent.com/11985637/234748830-892a8b0b-8615-4633-be8f-255f7959f998.png)
