### PR TITLE
Ensure that PROT_WRITE also sets PAGE_U to avoid segfaults

### DIFF
--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -1055,7 +1055,7 @@ static u64 Prot2Page(int prot) {
   u64 key = 0;
   if (prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC)) return einval();
   if (prot & PROT_READ) key |= PAGE_U;
-  if (prot & PROT_WRITE) key |= PAGE_RW;
+  if (prot & PROT_WRITE) key |= PAGE_RW | PAGE_U;
   if (~prot & PROT_EXEC) key |= PAGE_XD;
   return key;
 }


### PR DESCRIPTION
Motivation for this change below. This PR this fixes my issue, but I don't know if it's the *correct* fix :slightly_smiling_face:

```
$ cat test.c
#include <stdio.h>
#include <sys/mman.h>
#include <sys/types.h>
#include <fcntl.h>
#include <stdint.h>
#include <unistd.h>
int main() {
    unlink("/tmp/x");
    int fd = open("/tmp/x", O_RDWR | O_CREAT | O_TRUNC);
    printf("fd = %i\n", fd);
    int ret = ftruncate(fd, sizeof(uint64_t));
    printf("ret = %i\n", ret);
    void *ptr = mmap(NULL, sizeof(uint64_t), PROT_WRITE, MAP_SHARED, fd, 0);
    printf("ptr = %p\n", ptr);
    *((uint64_t *)ptr) = 15;
}
$ musl-gcc -static test.c; ./a.out; echo ====; ./blink/o/blink/blink -m -j -C ubuntu-22.04 ./a.out
fd = 3
ret = 0
ptr = 0x7f90c6b15000
====
fd = 3
ret = 0
ptr = 0x200000000000
E2023-04-28T00:10:53.393062:blink/blink.c:158:463160 terminating due to SIGSEGV (rip=0x4011fc code=2 faultaddr=0x200000000000)
E2023-04-28T00:10:53.393264:blink/blink.c:142:463160 additional information
         PC 4011fc movq $15,(%rax) 48 c7 00 0f 00 00 00 b8
         AX 0000200000000000  CX 0000000000000000  DX 0000000000000000  BX 0000000000401139
         SP 00004ffffffff140  BP 00004ffffffff150  SI 0000000000405023  DI 0000000000407208
         R8 00004fffffffee5b  R9 0000000000407040 R10 000000000000000e R11 0000000000405023
        R12 00004ffffffff198 R13 00004ffffffff1a8 R14 0000000000000000 R15 0000000000000000
         FS 0000000000407678  GS 0000000000000000 OPS 2002             FLG ......
        ./a.out
        4ffffffff150 0000004011fc main+0xc3 16 bytes
        000000000001 0000004014ce libc_start_main_stage2+0x2e [STRAY] [MISALIGN] [CORRUPT FRAME POINTER]
000000400000-000000400fff  4096 100% r   ./a.out
000000401000-000000404fff   16k 100% rx  ./a.out
000000405000-000000405fff  4096 100% r   ./a.out
000000406000-000000407fff  8192 100% rw  ./a.out
200000000000-200000000fff* 4096 100% w   /tmp/x
4fffff800000-4fffffffffff 8192k   1% rw  [stack]
<blink backtrace unavailable>
Segmentation fault (core dumped)
```

Looking at the code, `Prot2Page` does not set `PAGE_U` if only `PROT_WRITE` is set https://github.com/jart/blink/blob/ae9653a7a98b252ac0625f111bcfecda804889ce/blink/syscall.c#L1055-L1062

But the chain of `OpMovImm` -> `GetModrmWriteBW` -> `ComputeReserveAddressWrite` -> `ReserveAddress` calls `ReserveAddress` with writable=true, which then hits https://github.com/jart/blink/blob/ae9653a7a98b252ac0625f111bcfecda804889ce/blink/memory.c#L413