### PR TITLE
[metal] Disk I/O implementation improvements

### DIFF
--- a/blink/defbios.c
+++ b/blink/defbios.c
@@ -186,3 +186,7 @@ void SetDefaultBiosDataArea(struct Machine *m) {
   Write16(m->system->real + 0x413, 0xb0000 / 1024);
   Write16(m->system->real + 0x44A, 80);
 }
+
+u32 GetDefaultBiosDisketteParamTable(void) {
+  return kBiosSeg << 16 | (kBiosDefInt0x1E - kBiosBase);
+}

--- a/blink/defbios.c
+++ b/blink/defbios.c
@@ -70,160 +70,50 @@
 #define kBiosDefInt0x76 (kBiosDefInt0x75 + 4)
 #define kBiosDefInt0x77 (kBiosDefInt0x76 + 4)
 
-static const u8 defbios[] = {[kBiosDefInt0x00 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0067,  // hvtailcall 0x00
-                             [kBiosDefInt0x01 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x01,  // hvtailcall 0x01
-                             [kBiosDefInt0x02 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x02,  // hvtailcall 0x02
-                             [kBiosDefInt0x03 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x03,  // hvtailcall 0x03
-                             [kBiosDefInt0x04 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x04,  // hvtailcall 0x04
-                             [kBiosDefInt0x05 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x05,  // hvtailcall 0x05
-                             [kBiosDefInt0x06 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x06,  // hvtailcall 0x06
-                             [kBiosDefInt0x07 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x07,  // hvtailcall 0x07
-                             [kBiosDefInt0x08 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x08,  // hvtailcall 0x08
-                             [kBiosDefInt0x09 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x09,  // hvtailcall 0x09
-                             [kBiosDefInt0x0A - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x0A,  // hvtailcall 0x0A
-                             [kBiosDefInt0x0B - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x0B,  // hvtailcall 0x0B
-                             [kBiosDefInt0x0C - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x0C,  // hvtailcall 0x0C
-                             [kBiosDefInt0x0D - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x0D,  // hvtailcall 0x0D
-                             [kBiosDefInt0x0E - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x0E,  // hvtailcall 0x0E
-                             [kBiosDefInt0x0F - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x0F,  // hvtailcall 0x0F
-                             [kBiosDefInt0x10 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x10,  // hvtailcall 0x10
-                             [kBiosDefInt0x11 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x11,  // hvtailcall 0x11
-                             [kBiosDefInt0x12 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x12,  // hvtailcall 0x12
-                             [kBiosDefInt0x13 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x13,  // hvtailcall 0x13
-                             [kBiosDefInt0x14 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x14,  // hvtailcall 0x14
-                             [kBiosDefInt0x15 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x15,  // hvtailcall 0x15
-                             [kBiosDefInt0x16 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x16,  // hvtailcall 0x16
-                             [kBiosDefInt0x17 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x17,  // hvtailcall 0x17
-                             [kBiosDefInt0x18 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x18,  // hvtailcall 0x18
-                             [kBiosDefInt0x19 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x19,  // hvtailcall 0x19
-                             [kBiosDefInt0x1A - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x1A,  // hvtailcall 0x1A
-                             [kBiosDefInt0x1B - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x1B,  // hvtailcall 0x1B
-                             [kBiosDefInt0x1C - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x1C,  // hvtailcall 0x1C
-                             [kBiosDefInt0x70 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x70,  // hvtailcall 0x70
-                             [kBiosDefInt0x71 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x71,  // hvtailcall 0x71
-                             [kBiosDefInt0x72 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x72,  // hvtailcall 0x72
-                             [kBiosDefInt0x73 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x73,  // hvtailcall 0x73
-                             [kBiosDefInt0x74 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x74,  // hvtailcall 0x74
-                             [kBiosDefInt0x75 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x75,  // hvtailcall 0x75
-                             [kBiosDefInt0x76 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x76,  // hvtailcall 0x76
-                             [kBiosDefInt0x77 - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0167,
-                             0x77,  // hvtailcall 0x77
-                             [kBiosEntry - kBiosArrayBase] = 0x0F,
-                             0xFF,
-                             0177,
-                             0x19,  // hvcall 0x19
-                             0xEB,
-                             0xFA,  // jmp .-4
-                             [kBiosEnd - 1 - kBiosArrayBase] = 0x00};
+#define BIOS_BYTES_AT(addr, ...) [((addr)) - kBiosArrayBase] = __VA_ARGS__
+
+static const u8 defbios[] = {
+    BIOS_BYTES_AT(kBiosDefInt0x00, 0x0F, 0xFF, 0067),        // hvtailcall 0x00
+    BIOS_BYTES_AT(kBiosDefInt0x01, 0x0F, 0xFF, 0167, 0x01),  // hvtailcall 0x01
+    BIOS_BYTES_AT(kBiosDefInt0x02, 0x0F, 0xFF, 0167, 0x02),  // hvtailcall 0x02
+    BIOS_BYTES_AT(kBiosDefInt0x03, 0x0F, 0xFF, 0167, 0x03),  // hvtailcall 0x03
+    BIOS_BYTES_AT(kBiosDefInt0x04, 0x0F, 0xFF, 0167, 0x04),  // hvtailcall 0x04
+    BIOS_BYTES_AT(kBiosDefInt0x05, 0x0F, 0xFF, 0167, 0x05),  // hvtailcall 0x05
+    BIOS_BYTES_AT(kBiosDefInt0x06, 0x0F, 0xFF, 0167, 0x06),  // hvtailcall 0x06
+    BIOS_BYTES_AT(kBiosDefInt0x07, 0x0F, 0xFF, 0167, 0x07),  // hvtailcall 0x07
+    BIOS_BYTES_AT(kBiosDefInt0x08, 0x0F, 0xFF, 0167, 0x08),  // hvtailcall 0x08
+    BIOS_BYTES_AT(kBiosDefInt0x09, 0x0F, 0xFF, 0167, 0x09),  // hvtailcall 0x09
+    BIOS_BYTES_AT(kBiosDefInt0x0A, 0x0F, 0xFF, 0167, 0x0A),  // hvtailcall 0x0A
+    BIOS_BYTES_AT(kBiosDefInt0x0B, 0x0F, 0xFF, 0167, 0x0B),  // hvtailcall 0x0B
+    BIOS_BYTES_AT(kBiosDefInt0x0C, 0x0F, 0xFF, 0167, 0x0C),  // hvtailcall 0x0C
+    BIOS_BYTES_AT(kBiosDefInt0x0D, 0x0F, 0xFF, 0167, 0x0D),  // hvtailcall 0x0D
+    BIOS_BYTES_AT(kBiosDefInt0x0E, 0x0F, 0xFF, 0167, 0x0E),  // hvtailcall 0x0E
+    BIOS_BYTES_AT(kBiosDefInt0x0F, 0x0F, 0xFF, 0167, 0x0F),  // hvtailcall 0x0F
+    BIOS_BYTES_AT(kBiosDefInt0x10, 0x0F, 0xFF, 0167, 0x10),  // hvtailcall 0x10
+    BIOS_BYTES_AT(kBiosDefInt0x11, 0x0F, 0xFF, 0167, 0x11),  // hvtailcall 0x11
+    BIOS_BYTES_AT(kBiosDefInt0x12, 0x0F, 0xFF, 0167, 0x12),  // hvtailcall 0x12
+    BIOS_BYTES_AT(kBiosDefInt0x13, 0x0F, 0xFF, 0167, 0x13),  // hvtailcall 0x13
+    BIOS_BYTES_AT(kBiosDefInt0x14, 0x0F, 0xFF, 0167, 0x14),  // hvtailcall 0x14
+    BIOS_BYTES_AT(kBiosDefInt0x15, 0x0F, 0xFF, 0167, 0x15),  // hvtailcall 0x15
+    BIOS_BYTES_AT(kBiosDefInt0x16, 0x0F, 0xFF, 0167, 0x16),  // hvtailcall 0x16
+    BIOS_BYTES_AT(kBiosDefInt0x17, 0x0F, 0xFF, 0167, 0x17),  // hvtailcall 0x17
+    BIOS_BYTES_AT(kBiosDefInt0x18, 0x0F, 0xFF, 0167, 0x18),  // hvtailcall 0x18
+    BIOS_BYTES_AT(kBiosDefInt0x19, 0x0F, 0xFF, 0167, 0x19),  // hvtailcall 0x19
+    BIOS_BYTES_AT(kBiosDefInt0x1A, 0x0F, 0xFF, 0167, 0x1A),  // hvtailcall 0x1A
+    BIOS_BYTES_AT(kBiosDefInt0x1B, 0x0F, 0xFF, 0167, 0x1B),  // hvtailcall 0x1B
+    BIOS_BYTES_AT(kBiosDefInt0x1C, 0x0F, 0xFF, 0167, 0x1C),  // hvtailcall 0x1C
+    BIOS_BYTES_AT(kBiosDefInt0x70, 0x0F, 0xFF, 0167, 0x70),  // hvtailcall 0x70
+    BIOS_BYTES_AT(kBiosDefInt0x71, 0x0F, 0xFF, 0167, 0x71),  // hvtailcall 0x71
+    BIOS_BYTES_AT(kBiosDefInt0x72, 0x0F, 0xFF, 0167, 0x72),  // hvtailcall 0x72
+    BIOS_BYTES_AT(kBiosDefInt0x73, 0x0F, 0xFF, 0167, 0x73),  // hvtailcall 0x73
+    BIOS_BYTES_AT(kBiosDefInt0x74, 0x0F, 0xFF, 0167, 0x74),  // hvtailcall 0x74
+    BIOS_BYTES_AT(kBiosDefInt0x75, 0x0F, 0xFF, 0167, 0x75),  // hvtailcall 0x75
+    BIOS_BYTES_AT(kBiosDefInt0x76, 0x0F, 0xFF, 0167, 0x76),  // hvtailcall 0x76
+    BIOS_BYTES_AT(kBiosDefInt0x77, 0x0F, 0xFF, 0167, 0x77),  // hvtailcall 0x77
+    BIOS_BYTES_AT(kBiosEntry,                                //
+                  0x0F, 0xFF, 0177, 0x19,                    // hvcall 0x19
+                  0xEB, 0xFA),                               // jmp .-4
+    BIOS_BYTES_AT(kBiosEnd - 1, 0x00)};
 
 void LoadDefaultBios(struct Machine *m) {
   size_t kBiosSize = sizeof(defbios);

--- a/blink/defbios.c
+++ b/blink/defbios.c
@@ -31,7 +31,7 @@
 #include "blink/endian.h"
 #include "blink/macros.h"
 
-#define kBiosArrayBase  ROUNDDOWN(kBiosEntry - (0x1D + 8) * 4, 0x10)
+#define kBiosArrayBase  ROUNDDOWN(kBiosEntry - (0x1D * 4 + 12 + 8 * 4), 0x10)
 #define kBiosDefInt0x00 kBiosArrayBase
 #define kBiosDefInt0x01 (kBiosDefInt0x00 + 4)
 #define kBiosDefInt0x02 (kBiosDefInt0x01 + 4)
@@ -61,7 +61,8 @@
 #define kBiosDefInt0x1A (kBiosDefInt0x19 + 4)
 #define kBiosDefInt0x1B (kBiosDefInt0x1A + 4)
 #define kBiosDefInt0x1C (kBiosDefInt0x1B + 4)
-#define kBiosDefInt0x70 (kBiosDefInt0x1C + 4)
+#define kBiosDefInt0x1E (kBiosDefInt0x1C + 4)
+#define kBiosDefInt0x70 (kBiosDefInt0x1E + 12)
 #define kBiosDefInt0x71 (kBiosDefInt0x70 + 4)
 #define kBiosDefInt0x72 (kBiosDefInt0x71 + 4)
 #define kBiosDefInt0x73 (kBiosDefInt0x72 + 4)
@@ -102,6 +103,11 @@ static const u8 defbios[] = {
     BIOS_BYTES_AT(kBiosDefInt0x1A, 0x0F, 0xFF, 0167, 0x1A),  // hvtailcall 0x1A
     BIOS_BYTES_AT(kBiosDefInt0x1B, 0x0F, 0xFF, 0167, 0x1B),  // hvtailcall 0x1B
     BIOS_BYTES_AT(kBiosDefInt0x1C, 0x0F, 0xFF, 0167, 0x1C),  // hvtailcall 0x1C
+    // default diskette parameter table per Jun 1985 PC AT BIOS; see p. 5-192 @
+    // https://archive.org/details/IBMPCATIBM5170TechnicalReference6280070SEP85
+    BIOS_BYTES_AT(kBiosDefInt0x1E,                           //
+                  0xDF, 2, 37, 2, 15,                        //
+                  0x1B, 0xFF, 0x54, 0xF6, 15, 8),            //
     BIOS_BYTES_AT(kBiosDefInt0x70, 0x0F, 0xFF, 0167, 0x70),  // hvtailcall 0x70
     BIOS_BYTES_AT(kBiosDefInt0x71, 0x0F, 0xFF, 0167, 0x71),  // hvtailcall 0x71
     BIOS_BYTES_AT(kBiosDefInt0x72, 0x0F, 0xFF, 0167, 0x72),  // hvtailcall 0x72
@@ -157,6 +163,7 @@ void SetDefaultBiosIntVectors(struct Machine *m) {
   Put32(s->real + 0x1A * 4, kBiosSeg << 16 | (kBiosDefInt0x1A - kBiosBase));
   Put32(s->real + 0x1B * 4, kBiosSeg << 16 | (kBiosDefInt0x1B - kBiosBase));
   Put32(s->real + 0x1C * 4, kBiosSeg << 16 | (kBiosDefInt0x1C - kBiosBase));
+  Put32(s->real + 0x1E * 4, kBiosSeg << 16 | (kBiosDefInt0x1E - kBiosBase));
   Put32(s->real + 0x70 * 4, kBiosSeg << 16 | (kBiosDefInt0x70 - kBiosBase));
   Put32(s->real + 0x71 * 4, kBiosSeg << 16 | (kBiosDefInt0x71 - kBiosBase));
   Put32(s->real + 0x72 * 4, kBiosSeg << 16 | (kBiosDefInt0x72 - kBiosBase));

--- a/blink/defbios.h
+++ b/blink/defbios.h
@@ -11,5 +11,6 @@
 void LoadDefaultBios(struct Machine *);
 void SetDefaultBiosIntVectors(struct Machine *);
 void SetDefaultBiosDataArea(struct Machine *);
+u32 GetDefaultBiosDisketteParamTable(void);
 
 #endif /* BLINK_DEFBIOS_H_ */

--- a/blink/loader.c
+++ b/blink/loader.c
@@ -478,7 +478,8 @@ static bool LoadElf(struct Machine *m,  //
 }
 
 void BootProgram(struct Machine *m,  //
-                 struct Elf *elf) {
+                 struct Elf *elf,    //
+                 u8 bootdrive) {
   int fd;
   SetDefaultBiosIntVectors(m);
   memset(m->beg, 0, sizeof(m->beg));  // reinitialize registers
@@ -487,6 +488,7 @@ void BootProgram(struct Machine *m,  //
   m->ip = 0x7c00;
   elf->base = 0x7c00;
   Write64(m->sp, 0x6f00);  // following QEMU
+  m->dl = bootdrive;
   SetDefaultBiosDataArea(m);
   memset(m->system->real + 0x500, 0, kBiosBase - 0x500);
   memset(m->system->real + 0x00100000, 0, kRealSize - 0x00100000);

--- a/blink/loader.h
+++ b/blink/loader.h
@@ -4,7 +4,7 @@
 #include "blink/machine.h"
 
 bool CanEmulateExecutable(struct Machine *, char **, char ***);
-void BootProgram(struct Machine *, struct Elf *);
+void BootProgram(struct Machine *, struct Elf *, u8);
 void LoadProgram(struct Machine *, char *, char *, char **, char **);
 void LoadDebugSymbols(struct System *);
 void LoadFileSymbols(struct System *, const char *, i64);

--- a/test/metal/biosdisk.S
+++ b/test/metal/biosdisk.S
@@ -1,0 +1,57 @@
+#include "test/metal/mac.inc"
+
+	.section .head,"ax",@progbits
+	.code16
+
+.globl	_start
+_start:
+
+//	make -j8 o//blink o//test/metal/biosdisk.bin
+//	o//blink/blinkenlights -r o//test/metal/biosdisk.bin
+
+	ljmpw	$0,$1f
+1:
+	.test	"int 0x1E diskette parameter table should contain sane values"
+	lds	%cs:(0x1e*4),%bx	// %ds:%bx := table pointer
+	mov	%ds,%ax			// test that pointer is not null
+	or	%bx,%ax
+	.ne
+	cmpb	$2,3(%bx)		// test that diskette I/O is using
+	.e				// 512 bytes per sector
+	cmpb	$8,4(%bx)		// ...& at least 8 sectors per track
+	.nc
+
+	test	%dl,%dl			// skip next test in unlikely case
+	jne	2f			// this was not booted from floppy
+					// drive A:
+
+	.test	"floppy parameters from int 0x13 should be sane"
+	xor	%di,%di			// get parameters for A:
+	mov	%di,%es
+	mov	$8,%ah
+	xor	%cx,%cx
+	int	$0x13
+	.nc
+	cmp	$8,%cl			// test that maximum sector number
+	.nc				// per track makes sense
+	cmp	$40-1,%ch		// test that maximum track number
+	.nc				// makes sense
+	test	%dl,%dl			// test that drive count makes sense
+	.ne
+	mov	%es,%ax			// test that parameter table pointer
+	or	%di,%ax			// is not null
+	.ne
+	cmpb	$2,%es:3(%di)		// test parameter table values for
+	.e				// this drive
+	cmpb	$8,%es:4(%di)
+	.nc
+
+2:
+	.exit
+
+// fabricate a 160 KiB disk image (40 tracks × 1 side × 8 sectors per track)
+
+	.global	_sectors
+	_sectors = 320
+
+	.section .pad,"a",@progbits

--- a/test/metal/metal.lds
+++ b/test/metal/metal.lds
@@ -38,14 +38,24 @@ SECTIONS {
     _edata = .;
   }
 
+  PROVIDE(_sectors = ALIGN(_edata - _base, 512) / 512);
+
   .bss : {
     *(.bss .bss.*)
     *(COMMON)
   }
 
+  .pad : {
+    /*
+     * If the program defines both a _sectors value & a .pad section, then
+     * pad the image up to the requested sector count.  This allows us to
+     * fabricate disk images that follow particular disk geometries.
+     */
+    . = MAX(., _base + _sectors * 512 - SIZEOF(.pad));
+    *(.pad .pad.*)
+  } = 0xF6
+
   /DISCARD/ : {
     *(.*)
   }
-
-  _sectors = ALIGN(_edata - _base, 512) / 512;
 }


### PR DESCRIPTION
- Add a default diskette parameter table (`int 0x1e`)
- Start telling apart floppy images and hard disk images &mdash; in particular, set `%dl` to `0x80` on boot sector entry, for a hard disk image