### PR TITLE
Add CGA 40x25 and BIOS Data Area console variables

### DIFF
--- a/blink/bda.h
+++ b/blink/bda.h
@@ -1,0 +1,39 @@
+#ifndef BLINK_BDA_H_
+#define BLINK_BDA_H_
+#include "blink/machine.h"
+#include "blink/endian.h"
+
+#define BDA(address)        (g_machine->system->real + address)
+
+#define    BdaVmode         Read8(BDA(0x0449))
+#define SetBdaVmode(v)      Write8(BDA(0x0449),v)
+#define    BdaCols          Read8(BDA(0x044A))
+#define SetBdaCols(v)       Write8(BDA(0x044A),v)
+#define    BdaPagesz        Read8(BDA(0x044C))
+#define SetBdaPagesz(v)     Write8(BDA(0x044C),v)
+#define    BdaCurx          Read8(BDA(0x0450))
+#define SetBdaCurx(v)       Write8(BDA(0x0450),v)
+#define    BdaCury          Read8(BDA(0x0451))
+#define SetBdaCury(v)       Write8(BDA(0x0451),v)
+#define    BdaCrtc          Read16(BDA(0x0464))
+#define SetBdaCrtc(v)       Write16(BDA(0x0464),v)
+#define    BdaCurend        Read8(BDA(0x0460))
+#define SetBdaCurend(v)     Write8(BDA(0x0460),v)
+#define    BdaCurstart      Read8(BDA(0x0461))
+#define SetBdaCurstart(v)   Write8(BDA(0x0461),v)
+#define BdaCurhidden        ((BdaCurstart & 0x20) || (BdaCurstart > BdaCurend))
+
+#if 0
+#define    BdaEquip         Read16(BDA(0x0410))
+#define SetBdaEquip(v)      Write16(BDA(0x0410),v)
+#define    BdaMemsz         Read16(BDA(0x0413))
+#define SetBdaMemsz(v)      Write16(BDA(0x0413),v)
+#define    BdaTimer         Read32(BDA(0x046C))
+#define SetBdaTimer(v)      Write32(BDA(0x046C),v)
+#define    Bda24hr          Read8(BDA(0x0470))
+#define SetBda24hr(v)       Write8(BDA(0x0470),v)
+#endif
+
+#define BdaLines            25
+
+#endif /* BLINK_BDA_H_ */

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -2454,7 +2454,6 @@ static void DrawDisplayOnly(void) {
   p = &pan.display;
   yn = MIN(tyn, p->bottom - p->top);
   xn = MIN(txn, p->right - p->left);
-  unassert(yn == 25);
   for (i = 0; i < yn; ++i) {
     p->lines[i].i = 0;
   }

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -2454,7 +2454,6 @@ static void DrawDisplayOnly(void) {
   p = &pan.display;
   yn = MIN(tyn, p->bottom - p->top);
   xn = MIN(txn, p->right - p->left);
-  unassert(xn > 0 && xn <= 80);
   unassert(yn == 25);
   for (i = 0; i < yn; ++i) {
     p->lines[i].i = 0;

--- a/blink/cga.h
+++ b/blink/cga.h
@@ -3,7 +3,7 @@
 #include "blink/panel.h"
 #include "blink/types.h"
 
-void DrawCga(struct Panel *, u8[25][80][2], int, int);
+void DrawCga(struct Panel *, u8 *);
 size_t FormatCga(u8, char[11]);
 
 #endif /* BLINK_CGA_H_ */

--- a/blink/mda.c
+++ b/blink/mda.c
@@ -17,6 +17,7 @@
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "blink/mda.h"
+#include "blink/bda.h"
 
 #include "blink/buffer.h"
 #include "blink/macros.h"
@@ -54,7 +55,7 @@ void DrawMda(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
     for (x = 0; x < 80; ++x) {
       ch = v[y][x][0];
       attr = v[y][x][1];
-      if (x == curx && y == cury) {
+      if (!BdaCurhidden && x == curx && y == cury) {
         if (ch == ' ' || ch == '\0') {
           ch = CURSOR;
           attr = 0x07;


### PR DESCRIPTION
Adds support for BIOS CGA modes 0 and 1 (40x25 text). 
All CGA/MDA variables are now stored in the BIOS Data Area for strict IBM PC compatibility.
Adds `Bda*` macros for accessing BIOS Data Area variables in `blink/bda.h`.
Implements cursor hide function.
Implement several more `int 10h` BIOS console functions.
Tracked down and fixed several bugs/crashes in BIOS console emulation, `unassert` macros left in.
R)eset now operates properly and resets the BIOS or pty screen when restarting the OS/boot emulation.
V)mode flip between BIOS mode 3 (CGA 80x25) and pty now works, which allows OS or boot sector startup in either of two modes, which is useful when the default BIOS mode 3 isn't desired.

Its now possible to boot a [TetrOS boot sector game](https://github.com/daniel-e/tetros/tree/master) which runs in CGA 40x25 mode. Unfortunately, it uses the arrow keys for moving the tetris blocks around and `int 16h` doesn't return scan codes yet so the user always loses.

Plans for the future are to setup BDA variables that might allow the ELKS direct console to run, which doesn't make BIOS calls but instead draws directly to video ram and talks to the 6845 CRT controller for cursor management.

Fairly heavily tested on ELKS, FreeDOS, SectorLISP, and TetrOS.

Here's TetrOS running in CGA 40x25 mode:
<img width="1466" alt="TetrOS blink" src="https://user-images.githubusercontent.com/11985637/235329976-1f4f2163-3916-4c5c-9461-912571bbdaa2.png">
