### PR TITLE
More fixes to BIOS INT 0x10 routines

### DIFF
--- a/blink/bda.h
+++ b/blink/bda.h
@@ -7,10 +7,12 @@
 
 #define    BdaVmode         Read8(BDA(0x0449))
 #define SetBdaVmode(v)      Write8(BDA(0x0449),v)
-#define    BdaCols          Read8(BDA(0x044A))
-#define SetBdaCols(v)       Write8(BDA(0x044A),v)
-#define    BdaPagesz        Read8(BDA(0x044C))
-#define SetBdaPagesz(v)     Write8(BDA(0x044C),v)
+#define    BdaCols          Read16(BDA(0x044A))         // returns actual # columns
+#define SetBdaCols(v)       Write16(BDA(0x044A),v)      // BIOS stores # columns
+#define    BdaLines         (Read8(BDA(0x0484)) + 1)    // returns actual # lines
+#define SetBdaLines(v)      Write8(BDA(0x0484),v)       // BIOS stores # lines - 1
+#define    BdaPagesz        Read16(BDA(0x044C))
+#define SetBdaPagesz(v)     Write16(BDA(0x044C),v)
 #define    BdaCurx          Read8(BDA(0x0450))
 #define SetBdaCurx(v)       Write8(BDA(0x0450),v)
 #define    BdaCury          Read8(BDA(0x0451))
@@ -22,8 +24,9 @@
 #define    BdaCurstart      Read8(BDA(0x0461))
 #define SetBdaCurstart(v)   Write8(BDA(0x0461),v)
 #define BdaCurhidden        ((BdaCurstart & 0x20) || (BdaCurstart > BdaCurend))
+#define    BdaCurpage       Read8(BDA(0x0462))
+#define SetBdaCurpage(v)    Write8(BDA(0x0462),v)
 
-#if 0
 #define    BdaEquip         Read16(BDA(0x0410))
 #define SetBdaEquip(v)      Write16(BDA(0x0410),v)
 #define    BdaMemsz         Read16(BDA(0x0413))
@@ -32,8 +35,5 @@
 #define SetBdaTimer(v)      Write32(BDA(0x046C),v)
 #define    Bda24hr          Read8(BDA(0x0470))
 #define SetBda24hr(v)       Write8(BDA(0x0470),v)
-#endif
-
-#define BdaLines            25
 
 #endif /* BLINK_BDA_H_ */

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -3040,11 +3040,33 @@ static void OnVidyaServiceScrollDown(void) {
   }
 }
 
-
 /* write char/attr to video adapter ram */
-static void VidyaServiceWriteVideoRam(u8 ch, u8 attr) {
-  u16 *vram;
+static void VidyaServiceWriteCharacter(u8 ch, u8 attr, int n, bool useattr) {
+  int x, y, xn, offset;
+  u8 *vram;
+  x = BdaCurx;
+  y = BdaCury;
+  unassert(y < BdaLines);
+  unassert(x < BdaCols);
+  xn = BdaCols;
+  vram = video_ram();
+  while (n-- > 0) {
+    offset = page_offsetw() + (y * xn + x) * 2;
+    vram[offset] = ch;
+    if (useattr) {
+      vram[offset+1] = attr;
+    }
+    if (++x >= xn) {
+      x = 0;
+      y++;
+    }
+  }
+}
+
+/* write char/attr as teletype output */
+static void VidyaServiceWriteTeletype(u8 ch, u8 attr) {
   int x, y, xn;
+  u16 *vram;
   x = BdaCurx;
   y = BdaCury;
   unassert(y < BdaLines);
@@ -3057,8 +3079,8 @@ static void VidyaServiceWriteVideoRam(u8 ch, u8 attr) {
   case '\n':
     goto scroll;
   case '\b':
-    if (--x <= 0) {
-      x = 0;
+    if (x > 0) {
+      x--;
     }
     goto update;
   case '\0':
@@ -3081,10 +3103,11 @@ update:
 }
 
 static void VidyaServiceSetMode(int mode) {
-  int cols;
+  int cols, lines;
   vidya = mode;
   if (LookupAddress(m, 0xB0000)) {
     ptyisenabled = true;
+    lines = 25;
     switch (mode) {
     case 0:     // CGA 40x25 16-gray
     case 1:     // CGA 40x25 16-color
@@ -3102,11 +3125,13 @@ static void VidyaServiceSetMode(int mode) {
     }
     if (mode == kModePty) return;
     SetBdaVmode(mode);
+    SetBdaLines(lines-1);   // EGA BIOS - max valid line #
     SetBdaCols(cols);
     SetBdaPagesz(cols * BdaLines * 2);
+    SetBdaCurpage(0);
     SetBdaCurx(0);
     SetBdaCury(0);
-    SetBdaCurstart(5);  // cursor ▂ scan lines 5..7 of 0..7
+    SetBdaCurstart(5);      // cursor ▂ scan lines 5..7 of 0..7
     SetBdaCurend(7);
     SetBdaCrtc(0x3D4);
     VidyaServiceClearScreen(0, 0, cols, BdaLines, ATTR_DEFAULT);
@@ -3138,10 +3163,6 @@ static void OnVidyaServiceSetCursorPosition(void) {
   int x, y;
   x = m->dl;
   y = m->dh;
-  if (x >= BdaCols) x = BdaCols - 1;
-  if (y >= BdaLines) y = BdaLines - 1;
-  unassert(x < BdaCols);
-  unassert(y < BdaLines);
   if (vidya == kModePty) {
     PtySetX(pty, x);
     PtySetY(pty, y);
@@ -3152,15 +3173,15 @@ static void OnVidyaServiceSetCursorPosition(void) {
 }
 
 static void OnVidyaServiceGetCursorPosition(void) {
-  m->dh = vidya == kModePty? pty->y: BdaCury;
-  m->dl = vidya == kModePty? pty->x: BdaCurx;
-  unassert(m->dl < BdaCols);
-  unassert(m->dh < BdaLines);
   if (vidya == kModePty) {
+    m->dh = pty->y;
+    m->dl = pty->x;
     // cursor ▂ scan lines 5..7 of 0..7 and hidden bit 0x20
     m->ch = 5 | !!(pty->conf & kPtyNocursor) << 5;
     m->cl = 7;
   } else {
+    m->dh = BdaCury;
+    m->dl = BdaCurx;
     m->ch = BdaCurstart;
     m->cl = BdaCurend;
   }
@@ -3188,30 +3209,21 @@ static void OnVidyaServiceReadCharacter(void) {
   x = BdaCurx;
   y = BdaCury;
   xn = BdaCols;
-  unassert(y < BdaLines);
-  unassert(x < BdaCols);
   vram = (u16 *)video_ram();
   chattr = vram[page_offsetw() + y * xn + x];
   Put16(m->ax, chattr);
 }
 
-/* write character and attribute, no cursor change */
-static void OnVidyaServiceWriteCharacter(void) {
-  int i, n, sx, sy;
+/* write character and possibly attribute, no cursor change */
+static void OnVidyaServiceWriteCharacter(bool useattr) {
+  int i, n;
   u64 w;
   char *p, buf[32];
   if (vidya != kModePty) {
     n = Get16(m->cx);
     unassert(n > 0 && n + BdaCurx <= BdaCols);
     unassert(BdaCury < BdaLines);
-    sx = BdaCurx;
-    sy = BdaCury;
-    for (i = n; i > 0; --i) {
-      SetBdaCury(sy);
-      VidyaServiceWriteVideoRam(m->al, m->bl);  // FIXME perhaps rewrite?
-    }
-    SetBdaCurx(sx);
-    SetBdaCury(sy);
+    VidyaServiceWriteCharacter(m->al, m->bl, n, useattr);
     return;
   }
   p = buf;
@@ -3240,7 +3252,7 @@ static wint_t VidyaServiceXlatTeletype(u8 c) {
   }
 }
 
-static void OnVidyaServiceTeletypeOutput(void) {
+static void OnVidyaServiceWriteTeletype(void) {
   int n;
   u64 w;
   char buf[12];
@@ -3249,7 +3261,7 @@ static void OnVidyaServiceTeletypeOutput(void) {
     ReactiveDraw();
   }
   if (vidya != kModePty) {
-    VidyaServiceWriteVideoRam(m->al, m->bl);
+    VidyaServiceWriteTeletype(m->al, m->bl);
     return;
   }
   n = 0 /* FormatCga(m->bl, buf) */;
@@ -3284,12 +3296,17 @@ static void OnVidyaService(void) {
       OnVidyaServiceReadCharacter();
       break;
     case 0x09:
-      OnVidyaServiceWriteCharacter();
+      OnVidyaServiceWriteCharacter(true);
+      Redraw(false);
+      DrawDisplayOnly();
+      break;
+    case 0x0A:
+      OnVidyaServiceWriteCharacter(false);
       Redraw(false);
       DrawDisplayOnly();
       break;
     case 0x0E:
-      OnVidyaServiceTeletypeOutput();
+      OnVidyaServiceWriteTeletype();
       Redraw(false);
       DrawDisplayOnly();
       break;

--- a/blink/cga.c
+++ b/blink/cga.c
@@ -55,6 +55,7 @@ void DrawCga(struct Panel *p, u8 *vram) {
     for (x = 0; x < nx; ++x) {
       ch = *v++;
       attr = *v++;
+      if (attr == 0) attr = 0x07;
       if (!BdaCurhidden && x == curx && y == cury) {
         if (ch == ' ' || ch == '\0') {
           ch = CURSOR;

--- a/blink/defbios.c
+++ b/blink/defbios.c
@@ -185,6 +185,7 @@ void SetDefaultBiosDataArea(struct Machine *m) {
                                        1 << 9);  // no. of serial devices
   Write16(m->system->real + 0x413, 0xb0000 / 1024);
   Write16(m->system->real + 0x44A, 80);
+  Write16(m->system->real + 0x484, 24);
 }
 
 u32 GetDefaultBiosDisketteParamTable(void) {


### PR DESCRIPTION
Implements BDA and BIOS fixes to allow FreeDOS install to display more accurately.

`VFRAME.COM` now works.

Rewrote `int 0x10` function 0x09 and added function 0x0A.

Implements EGA BIOS `Lines` variable at BDA+0x484 in order for FreeDOS and `vframes` to work. Frankly, I'm amazed at the amount of peeking and poking into the BDA that's done by DOS programs in order to operate correctly.

Removes various `unassert`s - turns out many DOS programs position the cursor off the screen and write. Real PC BIOS (and QEMU) don't do bounds checking and just index and draw into video RAM even though it may not be displayed. Ever.

Other `unassert`s left in, but these may also want to be removed in the future. For now, leaving them in gives some semblance of bounds checking, until another DOS program does something funky. At least we'll know about it.

Here is the now-correct FreeDOS installation screen after discontinuing install with `N`:


<img width="1522" alt="FreeDOS blink OK" src="https://user-images.githubusercontent.com/11985637/235513082-f8f19d11-0fa0-4b80-bc40-8bda1f15e525.png">

~~The only remaining problem with the FreeDOS installer is the reverse-video highlighting displayed during language selection. It must be doing something quite unnatural, as I haven't been able to figure that one out yet.~~ This was fixed by not writing the attribute byte in `int 0x10` function 0x0E.