### PR TITLE
Various minor changes

### DIFF
--- a/blink/atomic.h
+++ b/blink/atomic.h
@@ -15,11 +15,13 @@
 
 #define atomic_store_explicit(ptr, val, order) (*(ptr) = (val))
 
-#define atomic_exchange_explicit(ptr, val, order)        \
+#define atomic_exchange(ptr, val)                        \
   (sizeof(*(ptr)) == 8   ? Exchange64((u64 *)(ptr), val) \
    : sizeof(*(ptr)) == 4 ? Exchange32((u32 *)(ptr), val) \
    : sizeof(*(ptr)) == 2 ? Exchange16((u16 *)(ptr), val) \
                          : Exchange8((u8 *)(ptr), val))
+
+#define atomic_exchange_explicit(ptr, val, order) atomic_exchange(ptr, val)
 
 #define atomic_compare_exchange_strong_explicit(                             \
     ifthing, isequaltome, replaceitwithme, success_order, failure_order)     \

--- a/blink/bda.h
+++ b/blink/bda.h
@@ -1,39 +1,52 @@
 #ifndef BLINK_BDA_H_
 #define BLINK_BDA_H_
+#include "blink/blinkenlights.h"
 #include "blink/machine.h"
 #include "blink/endian.h"
 
-#define BDA(address)        (g_machine->system->real + address)
+#define GetBda8(o)     Read8(m->system->real + 0x400 + (o))
+#define SetBda8(o, v)  Write8(m->system->real + 0x400 + (o), (v))
+#define GetBda16(o)    Read16(m->system->real + 0x400 + (o))
+#define SetBda16(o, v) Write16(m->system->real + 0x400 + (o), (v))
+#define GetBda32(o)    Read32(m->system->real + 0x400 + (o))
+#define SetBda32(o, v) Write32(m->system->real + 0x400 + (o), (v))
 
-#define    BdaVmode         Read8(BDA(0x0449))
-#define SetBdaVmode(v)      Write8(BDA(0x0449),v)
-#define    BdaCols          Read16(BDA(0x044A))         // returns actual # columns
-#define SetBdaCols(v)       Write16(BDA(0x044A),v)      // BIOS stores # columns
-#define    BdaLines         (Read8(BDA(0x0484)) + 1)    // returns actual # lines
-#define SetBdaLines(v)      Write8(BDA(0x0484),v)       // BIOS stores # lines - 1
-#define    BdaPagesz        Read16(BDA(0x044C))
-#define SetBdaPagesz(v)     Write16(BDA(0x044C),v)
-#define    BdaCurx          Read8(BDA(0x0450))
-#define SetBdaCurx(v)       Write8(BDA(0x0450),v)
-#define    BdaCury          Read8(BDA(0x0451))
-#define SetBdaCury(v)       Write8(BDA(0x0451),v)
-#define    BdaCrtc          Read16(BDA(0x0464))
-#define SetBdaCrtc(v)       Write16(BDA(0x0464),v)
-#define    BdaCurend        Read8(BDA(0x0460))
-#define SetBdaCurend(v)     Write8(BDA(0x0460),v)
-#define    BdaCurstart      Read8(BDA(0x0461))
-#define SetBdaCurstart(v)   Write8(BDA(0x0461),v)
+#define    BdaCom1          GetBda16(0x00)
+#define SetBdaCom1(v)       SetBda16(0x00, (v))
+#define    BdaEbda          GetBda16(0x0E)
+#define SetBdaEbda(v)       SetBda16(0x0E, (v))
+
+#define    BdaEquip         GetBda16(0x10)
+#define SetBdaEquip(v)      SetBda16(0x10, (v))
+#define    BdaMemsz         GetBda16(0x13)
+#define SetBdaMemsz(v)      SetBda16(0x13, (v))
+
+#define    BdaVmode         GetBda8(0x49)
+#define SetBdaVmode(v)      SetBda8(0x49, (v))
+#define    BdaCols          GetBda16(0x4A)       // returns actual # columns
+#define SetBdaCols(v)       SetBda16(0x4A, (v))  // BIOS stores # columns
+#define    BdaPagesz        GetBda16(0x4C)
+#define SetBdaPagesz(v)     SetBda16(0x4C, (v))
+#define    BdaCurx          GetBda8(0x50)
+#define SetBdaCurx(v)       SetBda8(0x50, (v))
+#define    BdaCury          GetBda8(0x51)
+#define SetBdaCury(v)       SetBda8(0x51, (v))
+#define    BdaCurend        GetBda8(0x60)
+#define SetBdaCurend(v)     SetBda8(0x60, (v))
+#define    BdaCurstart      GetBda8(0x61)
+#define SetBdaCurstart(v)   SetBda8(0x61, (v))
 #define BdaCurhidden        ((BdaCurstart & 0x20) || (BdaCurstart > BdaCurend))
-#define    BdaCurpage       Read8(BDA(0x0462))
-#define SetBdaCurpage(v)    Write8(BDA(0x0462),v)
+#define    BdaCurpage       GetBda8(0x62)
+#define SetBdaCurpage(v)    SetBda8(0x62, (v))
+#define    BdaCrtc          GetBda16(0x64)
+#define SetBdaCrtc(v)       SetBda16(0x64, (v))
 
-#define    BdaEquip         Read16(BDA(0x0410))
-#define SetBdaEquip(v)      Write16(BDA(0x0410),v)
-#define    BdaMemsz         Read16(BDA(0x0413))
-#define SetBdaMemsz(v)      Write16(BDA(0x0413),v)
-#define    BdaTimer         Read32(BDA(0x046C))
-#define SetBdaTimer(v)      Write32(BDA(0x046C),v)
-#define    Bda24hr          Read8(BDA(0x0470))
-#define SetBda24hr(v)       Write8(BDA(0x0470),v)
+#define    BdaTimer         GetBda32(0x6C)
+#define SetBdaTimer(v)      SetBda32(0x6C, (v))
+#define    Bda24hr          GetBda8(0x70)
+#define SetBda24hr(v)       SetBda8(0x70, (v))
+
+#define    BdaLines         (GetBda8(0x84) + 1)     // returns actual # lines
+#define SetBdaLines(v)      SetBda8(0x84, (v) - 1) // BIOS stores # lines - 1
 
 #endif /* BLINK_BDA_H_ */

--- a/blink/bios.c
+++ b/blink/bios.c
@@ -495,7 +495,7 @@ void VidyaServiceSetMode(int mode) {
     }
     if (mode == kModePty) return;
     SetBdaVmode(mode);
-    SetBdaLines(lines-1);   // EGA BIOS - max valid line #
+    SetBdaLines(lines);   // EGA BIOS - max valid line #
     SetBdaCols(cols);
     SetBdaPagesz(cols * BdaLines * 2);
     SetBdaCurpage(0);
@@ -816,11 +816,11 @@ static void OnInt15h(void) {
 }
 
 static void OnEquipmentListService(void) {
-  Put16(m->ax, Get16(m->system->real + 0x410));
+  Put16(m->ax, BdaEquip);
 }
 
 static void OnBaseMemSizeService(void) {
-  Put16(m->ax, Get16(m->system->real + 0x413));
+  Put16(m->ax, BdaMemsz);
 }
 
 static void OnPrinterService(void) {

--- a/blink/defbios.c
+++ b/blink/defbios.c
@@ -28,6 +28,7 @@
 
 #include <string.h>
 
+#include "blink/bda.h"
 #include "blink/endian.h"
 #include "blink/macros.h"
 
@@ -176,16 +177,16 @@ void SetDefaultBiosIntVectors(struct Machine *m) {
 
 void SetDefaultBiosDataArea(struct Machine *m) {
   memset(m->system->real + 0x400, 0, 0x100);
-  Write16(m->system->real + 0x400, 0x3F8);
-  Write16(m->system->real + 0x40E, 0xb0000 >> 4);
-  Write16(m->system->real + 0x410, 1 << 0 |      // floppy drive
-                                       1 << 1 |  // math coprocessor
-                                       3 << 4 |  // initial video mode
-                                       0 << 6 |  // no. of floppy drives - 1
-                                       1 << 9);  // no. of serial devices
-  Write16(m->system->real + 0x413, 0xb0000 / 1024);
-  Write16(m->system->real + 0x44A, 80);
-  Write16(m->system->real + 0x484, 24);
+  SetBdaCom1(0x3F8);
+  SetBdaEbda(0xB0000 >> 4);
+  SetBdaEquip(1 << 0 |  // floppy drive
+              1 << 1 |  // math coprocessor
+              3 << 4 |  // initial video mode
+              0 << 6 |  // no. of floppy drives - 1
+              1 << 9);  // no. of serial devices
+  SetBdaMemsz(0xB0000 / 1024);
+  SetBdaCols(80);
+  SetBdaLines(25);
 }
 
 u32 GetDefaultBiosDisketteParamTable(void) {

--- a/blink/hostfs.c
+++ b/blink/hostfs.c
@@ -883,7 +883,11 @@ int HostfsFdatasync(struct VfsInfo *info) {
     return efault();
   }
   hostinfo = (struct HostfsInfo *)info->data;
+#ifdef HAVE_FDATASYNC
   return fdatasync(hostinfo->filefd);
+#else
+  return fsync(hostinfo->filefd);
+#endif
 }
 
 int HostfsFlock(struct VfsInfo *info, int operation) {

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -852,6 +852,8 @@ static void GenInterrupt(P, u8 trapno) {
           HaltMachine(m, trapno);
         } else {
           m->flags = SetFlag(m->flags, FLAGS_IF, false);
+          m->flags = SetFlag(m->flags, FLAGS_TF, false);
+          m->flags = SetFlag(m->flags, FLAGS_AC, false);
           LongBranch(A, isrseg, isroff);
         }
       }

--- a/blink/signal.c
+++ b/blink/signal.c
@@ -265,7 +265,8 @@ int ConsumeSignal(struct Machine *m, int *delivered, bool *restart) {
 
 void EnqueueSignal(struct Machine *m, int sig) {
   if (m && (1 <= sig && sig <= 64)) {
-    if ((m->signals |= 1ul << (sig - 1)) & ~m->sigmask) {
+    m->signals |= 1ul << (sig - 1);
+    if ((m->signals & ~m->sigmask)) {
       atomic_store_explicit(&m->attention, true, memory_order_release);
     }
   }

--- a/config.h.in
+++ b/config.h.in
@@ -35,6 +35,7 @@
 // #define HAVE_MKFIFOAT
 // #define HAVE_REALPATH
 // #define HAVE_SETREUID
+// #define HAVE_FDATASYNC
 // #define HAVE_STRCHRNUL
 // #define HAVE_VASPRINTF
 // #define HAVE_SETRESUID

--- a/configure
+++ b/configure
@@ -608,7 +608,7 @@ fi
 
 # attempt to polyfill c11 atomics if it's not available
 if ! config stdatomic "checking for stdatomic.h... "; then
-  CPPFLAGS="-isystem tool/stdatomic"
+  CPPFLAGS="-isystem tool/stdatomic ${CPPFLAGS}"
 fi
 
 if [ -z "${DISABLE_FORK}" ]; then

--- a/configure
+++ b/configure
@@ -655,6 +655,7 @@ fi
 ( config seekdir "checking for seekdir()... " uncomment "#define HAVE_SEEKDIR" ) &
 ( config realpath "checking for realpath()... " uncomment "#define HAVE_REALPATH" ) &
 ( config setreuid "checking for setreuid()... " uncomment "#define HAVE_SETREUID" ) &
+( config fdatasync "checking for fdatasync()... " uncomment "#define HAVE_FDATASYNC" ) &
 ( config sendto_zero "checking for sendto(0.0.0.0)... " uncomment "#define HAVE_SENDTO_ZERO" ) &
 wait
 ( config struct_timezone "checking for struct timezone... " uncomment "#define HAVE_STRUCT_TIMEZONE" ) &

--- a/tool/config/dup3.c
+++ b/tool/config/dup3.c
@@ -7,7 +7,7 @@
 int main(int argc, char *argv[]) {
   char path[128];
   snprintf(path, 128, "/tmp/blink.config.%d", getpid());
-  if (open(path, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC) != 3) return 1;
+  if (open(path, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600) != 3) return 1;
   if (fcntl(3, F_GETFD) != FD_CLOEXEC) return 2;
   if (dup3(3, 4, 0) != 4) return 3;
   if (fcntl(4, F_GETFD) != 0) return 4;

--- a/tool/config/fdatasync.c
+++ b/tool/config/fdatasync.c
@@ -1,0 +1,19 @@
+// checks for fdatasync() system call
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+  char path[128];
+  int fd, rc;
+  snprintf(path, 128, "/tmp/blink.config.%d", getpid());
+  fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+  if (fd == -1) return 1;
+  rc = fdatasync(fd);
+  if (rc == -1) return 2;
+  if (rc) return 3;
+  close(fd);
+  if (unlink(path)) return 4;
+  return 0;
+}


### PR DESCRIPTION
* Fix an issue in `./configure` test for `dup3()`
  - the compiler was warning &mdash; rightly &mdash; that a call to `open()` with `O_CREAT` did not specify file permissions
* Also, make `./configure` add to `$CPPFLAGS` &mdash; rather than clobbering it &mdash; if the host platform does not have its own `<stdatomic.h>`
* Test if host defines a `fdatasync()` function; if not, fall back on using `fsync()`
* [metal] When entering an interrupt handler via `int`, `int3`, etc., besides clearing the `IF` flag, also remember to clear the `TF` and `AC` flags
* [metal] Try to simplify code for dealing with the BIOS data area