### PR TITLE
Fix INT 16h function 1 called twice and lambda display in CGA/MDA output

### DIFF
--- a/blink/bios.c
+++ b/blink/bios.c
@@ -816,6 +816,11 @@ static void OnKeyboardServiceReadKeyPress(void) {
 }
 
 static void OnKeyboardServiceCheckKeyPress(void) {
+  if (savechar) {
+    m->ah = saveah;
+    m->al = saveal;
+    return;
+  }
   bool b = HasPendingKeyboard();
   m->flags = SetFlag(m->flags, FLAGS_ZF, !b);   /* ZF=0 if key pressed */
   if (b) {
@@ -823,6 +828,9 @@ static void OnKeyboardServiceCheckKeyPress(void) {
     savechar = true;
     saveah = m->ah;
     saveal = m->al;
+  } else {
+    m->ah = 0;
+    m->al = 0;
   }
 }
 

--- a/blink/cga.c
+++ b/blink/cga.c
@@ -54,6 +54,7 @@ void DrawCga(struct Panel *p, u8 *vram) {
     v = vram + y * nx * 2;
     for (x = 0; x < nx; ++x) {
       ch = *v++;
+      if (ch == 0xFF) ch = 0x00;
       attr = *v++;
       if (!BdaCurhidden && x == curx && y == cury) {
         if (ch == ' ' || ch == '\0') {

--- a/blink/mda.c
+++ b/blink/mda.c
@@ -54,6 +54,7 @@ void DrawMda(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
     a = -1;
     for (x = 0; x < 80; ++x) {
       ch = v[y][x][0];
+      if (ch == 0xFF) ch = 0x00;
       attr = v[y][x][1];
       if (!BdaCurhidden && x == curx && y == cury) {
         if (ch == ' ' || ch == '\0') {


### PR DESCRIPTION
Fixes problems seen in FreeDOS 1.3 installer and GWBASIC.