### PR TITLE
[metal] Tweak display of CP437 characters in CGA/MDA window

### DIFF
--- a/blink/bios.c
+++ b/blink/bios.c
@@ -558,21 +558,6 @@ static void OnVidyaServiceGetCursorPosition(void) {
   }
 }
 
-static int GetVidyaByte(unsigned char b) {
-  if (0x20 <= b && b <= 0x7F) return b;
-#if 0
-  /*
-   * The original hardware displayed 0x00, 0x20, and 0xff as space. It
-   * made sense for viewing sparse binary data that 0x00 be blank. But
-   * it doesn't make sense for dense data too, and we don't need three
-   * space characters. So we diverge in our implementation and display
-   * 0xff as lambda.
-   */
-  if (b == 0xFF) b = 0x00;
-#endif
-  return kCp437[b];
-}
-
 static void OnVidyaServiceReadCharacter(void) {
   u16 *vram;
   u16 chattr;

--- a/blink/blinkenlights.h
+++ b/blink/blinkenlights.h
@@ -4,7 +4,11 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <wchar.h>
 #include <sys/types.h>
+
+#include "blink/likely.h"
+#include "blink/util.h"
 
 #define kModePty 255
 
@@ -27,5 +31,16 @@ ssize_t ReadAnsi(int fd, char *p, size_t n);
 /* bios.c */
 void VidyaServiceSetMode(int);
 bool OnCallBios(int interrupt);
+
+static inline wint_t GetVidyaByte(unsigned char b) {
+  if (LIKELY(0x20 <= b && b <= 0x7E)) return b;
+  /*
+   * In the emulated screen, show 0xff as a "shouldered open box"
+   * instead of lambda.  The Unicode 4.0 charts tell us that this
+   * glyph is an ISO 9995-7 "keyboard symbol for No Break Space".
+   */
+  if (UNLIKELY(b == 0xFF)) return 0x237D;
+  return kCp437[b];
+}
 
 #endif /* BLINK_BLINKENLIGHTS_H_ */

--- a/blink/cp437.c
+++ b/blink/cp437.c
@@ -18,6 +18,13 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "blink/util.h"
 
+/*
+ * The original hardware displayed 0x00, 0x20, and 0xff as space. It
+ * made sense for viewing sparse binary data that 0x00 be blank. But
+ * it doesn't make sense for dense data too, and we don't need three
+ * space characters. So we diverge in our implementation and display
+ * 0xff as lambda.
+ */
 const short kCp437[256] = /* clang-format off */ {
   0x00a0,0x263a,0x263b,0x2665,0x2666,0x2663,0x2660,0x2022, /*00: ☺☻♥♦♣♠•*/
   0x25d8,0x25cb,0x25d9,0x2642,0x2640,0x266a,0x266b,0x263c, /*08:◘○◙♂♀♪♫☼*/

--- a/blink/mda.c
+++ b/blink/mda.c
@@ -19,6 +19,7 @@
 #include "blink/mda.h"
 #include "blink/bda.h"
 
+#include "blink/blinkenlights.h"
 #include "blink/buffer.h"
 #include "blink/macros.h"
 #include "blink/util.h"
@@ -49,24 +50,24 @@ static u8 DecodeMdaAttributes(i8 a) {
 
 void DrawMda(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
   unsigned y, x, n, a, b, ch, attr;
+  wint_t wch;
   n = MIN(25, p->bottom - p->top);
   for (y = 0; y < n; ++y) {
     a = -1;
     for (x = 0; x < 80; ++x) {
       ch = v[y][x][0];
-      if (ch == 0xFF) ch = 0x00;
       attr = v[y][x][1];
       if (!BdaCurhidden && x == curx && y == cury) {
         if (ch == ' ' || ch == '\0') {
           ch = CURSOR;
           attr = 0x07;
         } else {
-          ch = kCp437[ch];
+          wch = GetVidyaByte(ch);
           attr = 0x70;
         }
         a = -1;
       } else {
-        ch = kCp437[ch];
+        wch = GetVidyaByte(ch);
       }
       b = DecodeMdaAttributes(attr);
       if (a != b) {
@@ -78,7 +79,7 @@ void DrawMda(struct Panel *p, u8 v[25][80][2], int curx, int cury) {
         if (a & kReverse) AppendStr(&p->lines[y], ";7");
         AppendChar(&p->lines[y], 'm');
       }
-      AppendWide(&p->lines[y], ch);
+      AppendWide(&p->lines[y], wch);
     }
   }
 }


### PR DESCRIPTION
* display ASCII characters 0x20--0x7E as-is
* display 0xFF as less intrusive symbol for No Break Space
* display 0x7F as "house", following actual hardware, rather than passing verbatim to host TTY