### PR TITLE
[metal] Ignore writes to BIOS code area

### DIFF
--- a/blink/biosrom.c
+++ b/blink/biosrom.c
@@ -32,6 +32,7 @@
 #include <string.h>
 
 #include "blink/bda.h"
+#include "blink/builtin.h"
 #include "blink/endian.h"
 #include "blink/macros.h"
 #include "blink/map.h"
@@ -167,14 +168,17 @@ void LoadBios(struct Machine *m, const char *biosprog) {
     size = sizeof(kDefBios);
     memcpy(m->system->real + kBiosEnd - size, kDefBios, size);
   }
+#ifndef DISABLE_ROM
   // try to protect the BIOS ROM area
-  // TODO: ideally writes will seem to succeed but have no effect
+  // BeginStore() & EndStore() will avoid scribbling in this area of
+  // memory: so writes to the guest ROM area are effectively ignored
   protstart = ROUNDUP(kBiosOptBase, FLAG_pagesize);
   protend = ROUNDDOWN(kBiosEnd, FLAG_pagesize);
   if (protstart < protend) {
     Mprotect(m->system->real + protstart, protend - protstart, PROT_READ,
              "bios");
   }
+#endif
   // load %cs:%rip
   m->cs.sel = kBiosSeg;
   m->cs.base = kBiosBase;

--- a/blink/biosrom.h
+++ b/blink/biosrom.h
@@ -9,7 +9,26 @@
                                        // BIOS image, including option ROMs
 
 #if !(__ASSEMBLER__ + __LINKER__ + 0)
+#include "blink/builtin.h"
+#include "blink/endian.h"
 #include "blink/machine.h"
+
+MICRO_OP_SAFE bool IsRomAddress(struct Machine *m, u8 *r) {
+#ifndef DISABLE_ROM
+  if (m->metal) {
+    u8 *real = m->system->real;
+#if CAN_ABUSE_POINTERS
+    ptrdiff_t d = r - real;
+    // gcc optimizes this conjunction into subtraction followed by comparison
+    // FIXME: find better way to figure out if we can abuse ptrdiff_t like so
+    if (kBiosOptBase <= d && d < kBiosEnd) return true;
+#else
+    if (&real[kBiosOptBase] <= r && r < &real[kBiosEnd]) return true;
+#endif
+  }
+#endif
+  return false;
+}
 
 void LoadBios(struct Machine *, const char *);
 void SetDefaultBiosIntVectors(struct Machine *);

--- a/blink/memorymalloc.c
+++ b/blink/memorymalloc.c
@@ -1392,6 +1392,9 @@ i64 ConvertHostToGuestAddress(struct System *s, void *ha, u64 *out_pte) {
   i64 g48;
   uintptr_t base;
   if (out_pte) *out_pte = 0;
+  if (s->mode.genmode == XED_GEN_MODE_REAL || !(s->cr0 & CR0_PG)) {
+    return (uintptr_t)ha;
+  }
   if ((uintptr_t)ha < kNullSize) return (uintptr_t)ha;
   if (HasLinearMapping() && !out_pte) return ToGuest(ha);
   base = (uintptr_t)ha & -4096;

--- a/blink/string.c
+++ b/blink/string.c
@@ -23,6 +23,7 @@
 
 #include "blink/alu.h"
 #include "blink/atomic.h"
+#include "blink/biosrom.h"
 #include "blink/builtin.h"
 #include "blink/bus.h"
 #include "blink/endian.h"
@@ -274,7 +275,7 @@ static void RepStosbEnhanced(P) {
       diremain = 4096 - (diactual & 4095);
       diremain = MIN(diremain, 65536 - dilow);
       n = MIN(cx, diremain);
-      memset(direal, m->al, n);
+      if (!IsRomAddress(m, direal)) memset(direal, m->al, n);
       AddDi(A, n);
       cx = SubtractCx(A, n);
       if (cx) diactual = AddressDi(A);

--- a/config.h.in
+++ b/config.h.in
@@ -15,6 +15,7 @@
 // #define DISABLE_METAL
 // #define DISABLE_MMX
 // #define DISABLE_BCD
+// #define DISABLE_ROM
 // #define DISABLE_BMI2
 
 // #define HAVE_FORK

--- a/configure
+++ b/configure
@@ -104,6 +104,9 @@ if [ "$1" = "--help" ]; then
   echo "  --disable-bcd"
   echo "    disables i8086 binary coded decimal support (shaves ~1kb off MODE=tiny)"
   echo
+  echo "  --disable-rom"
+  echo "    disables write protection of metal bios (shaves ~256 bytes off MODE=tiny)"
+  echo
   echo "  --disable-all"
   echo "    disable all optional features (shaves ~81kb off MODE=tiny)"
   echo "    you may use --enable-FOO to turn features back on"
@@ -411,6 +414,11 @@ for x; do
     comment "#define DISABLE_BCD"
   elif [ x"$x" = x"--disable-bcd" ]; then
     uncomment "#define DISABLE_BCD"
+
+  elif [ x"$x" = x"--enable-rom" ]; then
+    comment "#define DISABLE_ROM"
+  elif [ x"$x" = x"--disable-rom" ]; then
+    uncomment "#define DISABLE_ROM"
 
   elif [ x"$x" = x"--posix" ]; then
     CPPFLAGS="-D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -std=c11"


### PR DESCRIPTION
Also add a `--disable-rom` build option which will effectively make the BIOS code area read/write, like normal RAM.  This shaves around 200 bytes off a `MODE = tiny` Blink executable, at the cost of breaking emulation fidelity.