### PR TITLE
x86-64 host optimizations

### DIFF
--- a/blink/alu.h
+++ b/blink/alu.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 #include "blink/builtin.h"
+#include "blink/intrin.h"
 #include "blink/machine.h"
 #include "blink/types.h"
 
@@ -138,6 +139,48 @@ i64 Adox64(u64, u64, struct Machine *);
 
 #ifndef HAVE_JIT
 #define kAluFast kAlu
+#endif
+
+// the combinations of needed flags for which we can use kAluFast[];
+// the no-flags case (0) which uses kJustAlu[] is handled separately
+#if defined(HAVE_JIT) && X86_INTRINSICS
+#define CASE_ALU_FAST         \
+  case CF:                    \
+  case ZF:                    \
+  case CF | ZF:               \
+  case SF:                    \
+  case SF | CF:               \
+  case SF | ZF:               \
+  case SF | CF | ZF:          \
+  case AF:                    \
+  case AF | CF:               \
+  case AF | ZF:               \
+  case AF | CF | ZF:          \
+  case SF | AF:               \
+  case SF | AF | CF:          \
+  case SF | AF | ZF:          \
+  case SF | AF | CF | ZF:     \
+  case OF:                    \
+  case OF | CF:               \
+  case OF | ZF:               \
+  case OF | CF | ZF:          \
+  case OF | SF:               \
+  case OF | SF | CF:          \
+  case OF | SF | ZF:          \
+  case OF | SF | CF | ZF:     \
+  case OF | AF:               \
+  case OF | AF | CF:          \
+  case OF | AF | ZF:          \
+  case OF | AF | CF | ZF:     \
+  case OF | SF | AF:          \
+  case OF | SF | AF | CF:     \
+  case OF | SF | AF | ZF:     \
+  case OF | SF | AF | CF | ZF
+#else
+#define CASE_ALU_FAST         \
+  case CF:                    \
+  case ZF:                    \
+  case CF | ZF
 #endif
 
 #endif /* BLINK_ALU_H_ */

--- a/blink/alu2.c
+++ b/blink/alu2.c
@@ -200,9 +200,7 @@ void OpAluw(P) {
                  "r0D",  // PutRegOrMem(RexbRm, res0)
                  kJustAlu[t]);
           break;
-        case CF:
-        case ZF:
-        case CF | ZF:
+        CASE_ALU_FAST:
           STATISTIC(++alu_simplified);
           Jitter(A,
                  "q"     // arg0 = machine

--- a/blink/alui.c
+++ b/blink/alui.c
@@ -31,9 +31,7 @@ static void AluiRo(P, const aluop_f ops[4], const aluop_f fast[4]) {
     STATISTIC(++alu_ops);
     switch (GetNeededFlags(m, m->ip, CF | ZF | SF | OF | AF | PF)) {
       case 0:
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "B"      // res0 = GetRegOrMem(RexbRm)
@@ -76,9 +74,7 @@ static void AluiUnlocked(P, u8 *p, aluop_f op) {
                "r0D",  // PutRegOrMem(RexbRm, res0)
                kJustAlu[ModrmReg(rde)]);
         break;
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "q"     // arg0 = sav0 (machine)

--- a/blink/jit.c
+++ b/blink/jit.c
@@ -2029,6 +2029,18 @@ bool AppendJitNop(struct JitBlock *jb) {
 }
 
 /**
+ * Appends pause instruction.
+ */
+bool AppendJitPause(struct JitBlock *jb) {
+#if defined(__x86_64__)
+  u8 buf[2] = {0xf3, 0x90};  // pause
+#elif defined(__aarch64__)
+  u32 buf[1] = {0xd503203f};  // yield
+#endif
+  return AppendJit(jb, buf, sizeof(buf));
+}
+
+/**
  * Appends debugger breakpoint.
  */
 bool AppendJitTrap(struct JitBlock *jb) {

--- a/blink/jit.h
+++ b/blink/jit.h
@@ -228,6 +228,7 @@ struct JitBlock *StartJit(struct Jit *, i64);
 bool AlignJit(struct JitBlock *, int, int);
 bool AppendJitRet(struct JitBlock *);
 bool AppendJitNop(struct JitBlock *);
+bool AppendJitPause(struct JitBlock *);
 bool AppendJitTrap(struct JitBlock *);
 bool AppendJitJump(struct JitBlock *, void *);
 bool AppendJitCall(struct JitBlock *, void *);

--- a/blink/machine.c
+++ b/blink/machine.c
@@ -472,9 +472,7 @@ static void AluRo(P, const aluop_f ops[4], const aluop_f fops[4]) {
     LoadAluArgs(A);
     switch (GetNeededFlags(m, m->ip, CF | ZF | SF | OF | AF | PF)) {
       case 0:
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "q"   // arg0 = sav0 (machine)
@@ -531,9 +529,7 @@ static void OpAluFlip(P) {
                "r0C",  // PutReg(RexrReg, res0)
                kJustAlu[(Opcode(rde) & 070) >> 3]);
         break;
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "q"     // arg0 = sav0 (machine)
@@ -561,9 +557,7 @@ static void OpAluFlipCmp(P) {
     LoadAluFlipArgs(A);
     switch (GetNeededFlags(m, m->ip, CF | ZF | SF | OF | AF | PF)) {
       case 0:
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "q"   // arg0 = sav0 (machine)
@@ -587,9 +581,7 @@ static void OpAluAxImm(P) {
   if (IsMakingPath(m)) {
     switch (GetNeededFlags(m, m->ip, CF | ZF | SF | OF | AF | PF)) {
       case 0:
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "G"      // res0 = %ax
@@ -620,9 +612,7 @@ static void OpRoAxImm(P, const aluop_f ops[4], const aluop_f fops[4]) {
     STATISTIC(++alu_ops);
     switch (GetNeededFlags(m, m->ip, CF | ZF | SF | OF | AF | PF)) {
       case 0:
-      case CF:
-      case ZF:
-      case CF | ZF:
+      CASE_ALU_FAST:
         STATISTIC(++alu_simplified);
         Jitter(A,
                "G"      // r0 = GetReg(AX)

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -755,8 +755,6 @@ void OpTest(P);
 void OpAlui(P);
 void LoadAluArgs(P);
 void LoadAluFlipArgs(P);
-i64 FastAnd8(struct Machine *, u64, u64);
-i64 FastSub8(struct Machine *, u64, u64);
 void ZeroRegFlags(struct Machine *, long);
 
 i32 Imul32(i32, i32, struct Machine *);

--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -5373,7 +5373,7 @@ static i32 EpollPwait(struct Machine *m, i32 epfd, i64 eventsaddr,
       } else {
         waitfor = GetZeroTime();
       }
-#ifdef HAVE_EPOLL_PWAIT2
+#if defined(HAVE_EPOLL_PWAIT2) && !defined(MUSL_CROSS_MAKE)
       rc = epoll_pwait2(epfd, events, maxevents, &waitfor, &oldmask);
 #else
       rc = epoll_pwait(epfd, events, maxevents,

--- a/blink/time.c
+++ b/blink/time.c
@@ -24,6 +24,7 @@
 #include "blink/atomic.h"
 #include "blink/builtin.h"
 #include "blink/endian.h"
+#include "blink/jit.h"
 #include "blink/machine.h"
 #include "blink/modrm.h"
 
@@ -39,6 +40,9 @@ void OpPause(P) {
 #elif defined(HAVE_SCHED_YIELD)
   sched_yield();
 #endif
+  if (IsMakingPath(m)) {
+    AppendJitPause(m->path.jb);
+  }
 }
 
 void OpRdtsc(P) {

--- a/blink/uop.c
+++ b/blink/uop.c
@@ -89,28 +89,21 @@ const nexgen32e_f kConvert[] = {Convert16, Convert32, Convert64};
 
 #if X86_INTRINSICS
 MICRO_OP i64 Adcx32(u64 x, u64 y, struct Machine *m) {
-  u32 z, t;
-  asm("btr\t%5,%1\n\t"
-      "adc\t%4,%0\n\t"
-      "sbb\t%2,%2\n\t"
-      "and\t%6,%2\n\t"
-      "or\t%2,%1"
-      : "=&r" (z), "+&g" (m->flags), "=&r" (t)
-      : "%0" ((u32)x), "g" ((u32)y), "i" (FLAGS_CF), "i" (CF)
-      : "cc");
+  u32 z;
+  _Static_assert(CF == 1, "");
+  asm("btr\t$0,%1\n\t"
+      "adc\t%3,%0\n\t"
+      "adc\t$0,%1"
+      : "=&r" (z), "+&g" (m->flags) : "%0" ((u32)x), "g" ((u32)y) : "cc");
   return z;
 }
 MICRO_OP i64 Adcx64(u64 x, u64 y, struct Machine *m) {
   u64 z;
-  u32 t;
-  asm("btr\t%5,%1\n\t"
-      "adc\t%4,%0\n\t"
-      "sbb\t%2,%2\n\t"
-      "and\t%6,%2\n\t"
-      "or\t%2,%1"
-      : "=&r" (z), "+&g" (m->flags), "=&r" (t)
-      : "%0" (x), "g" (y), "i" (FLAGS_CF), "i" (CF)
-      : "cc");
+  _Static_assert(CF == 1, "");
+  asm("btr\t$0,%1\n\t"
+      "adc\t%3,%0\n\t"
+      "adc\t$0,%1"
+      : "=&r" (z), "+&g" (m->flags) : "%0" (x), "g" (y) : "cc");
   return z;
 }
 MICRO_OP i64 Adox32(u64 x, u64 y, struct Machine *m) {

--- a/blink/uop.c
+++ b/blink/uop.c
@@ -962,6 +962,122 @@ const aluop_f kJustBsu32[8] = {
     (aluop_f)JustSar32,  //
 };
 
+#if X86_INTRINSICS
+#define ALU_FAST(M, TYPE, X, Y, OP, COMMUT)                             \
+  ({                                                                    \
+    TYPE Res;                                                           \
+    u32 OldFlags = (M)->flags & ~(OF | SF | ZF | AF | CF);              \
+    u64 NewFlags;                                                       \
+    asm(OP "\t%3,%0\n\t"                                                \
+        "pushfq\n\t"                                                    \
+        "pop\t%1"                                                       \
+        : "=&r" (Res), "=r" (NewFlags)                                  \
+        : COMMUT "0" ((TYPE)(X)), "g" ((TYPE)(Y))                       \
+        : "cc");                                                        \
+    (M)->flags = OldFlags | ((u32)NewFlags & (OF | SF | ZF | AF | CF)); \
+    Res;                                                                \
+  })
+#define ALU_FAST_CF(M, TYPE, X, Y, OP, COMMUT)                          \
+  ({                                                                    \
+    TYPE Res;                                                           \
+    u32 OldFlags = (M)->flags & ~(OF | SF | ZF | AF);                   \
+    u64 NewFlags;                                                       \
+    asm("btr\t%5,%2\n\t"                                                \
+        OP "\t%4,%0\n\t"                                                \
+        "pushfq\n\t"                                                    \
+        "pop\t%1"                                                       \
+        : "=&r" (Res), "=r" (NewFlags), "+&r" (OldFlags)                \
+        : COMMUT "0" ((TYPE)(X)), "g" ((TYPE)(Y)),                      \
+          "i" (FLAGS_CF)                                                \
+        : "cc");                                                        \
+    (M)->flags = OldFlags | ((u32)NewFlags & (OF | SF | ZF | AF | CF)); \
+    Res;                                                                \
+  })
+MICRO_OP static i64 FastXor64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u64, x, y, "xor", "%");
+}
+MICRO_OP static i64 FastOr64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u64, x, y, "or", "%");
+}
+MICRO_OP static i64 FastAnd64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u64, x, y, "and", "%");
+}
+MICRO_OP static i64 FastSub64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u64, x, y, "sub", "");
+}
+MICRO_OP static i64 FastAdd64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u64, x, y, "add", "%");
+}
+MICRO_OP static i64 FastAdc64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u64, x, y, "adc", "%");
+}
+MICRO_OP static i64 FastSbb64(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u64, x, y, "sbb", "");
+}
+MICRO_OP static i64 FastXor32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u32, x, y, "xor", "%");
+}
+MICRO_OP static i64 FastOr32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u32, x, y, "or", "%");
+}
+MICRO_OP static i64 FastAnd32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u32, x, y, "and", "%");
+}
+MICRO_OP static i64 FastSub32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u32, x, y, "sub", "");
+}
+MICRO_OP static i64 FastAdd32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u32, x, y, "add", "%");
+}
+MICRO_OP static i64 FastAdc32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u32, x, y, "adc", "%");
+}
+MICRO_OP static i64 FastSbb32(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u32, x, y, "sbb", "");
+}
+MICRO_OP static i64 FastXor16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u16, x, y, "xor", "%");
+}
+MICRO_OP static i64 FastOr16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u16, x, y, "or", "%");
+}
+MICRO_OP static i64 FastAnd16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u16, x, y, "and", "%");
+}
+MICRO_OP static i64 FastSub16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u16, x, y, "sub", "");
+}
+MICRO_OP static i64 FastAdd16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u16, x, y, "add", "%");
+}
+MICRO_OP static i64 FastAdc16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u16, x, y, "adc", "%");
+}
+MICRO_OP static i64 FastSbb16(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u16, x, y, "sbb", "");
+}
+MICRO_OP static i64 FastXor8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u8, x, y, "xor", "%");
+}
+MICRO_OP static i64 FastOr8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u8, x, y, "or", "%");
+}
+MICRO_OP static i64 FastAnd8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u8, x, y, "and", "%");
+}
+MICRO_OP static i64 FastSub8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u8, x, y, "sub", "");
+}
+MICRO_OP static i64 FastAdd8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST(m, u8, x, y, "add", "%");
+}
+MICRO_OP static i64 FastAdc8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u8, x, y, "adc", "%");
+}
+MICRO_OP static i64 FastSbb8(struct Machine *m, u64 x, u64 y) {
+  return ALU_FAST_CF(m, u8, x, y, "sbb", "");
+}
+#else /* !X86_INTRINSICS */
 MICRO_OP static i64 FastXor64(struct Machine *m, u64 x, u64 y) {
   u64 z = x ^ y;
   m->flags = (m->flags & ~(CF | ZF)) | !z << FLAGS_ZF;
@@ -1129,6 +1245,7 @@ MICRO_OP static i64 FastSbb8(struct Machine *m, u64 x, u64 y) {
   m->flags = (m->flags & ~(CF | ZF)) | c << FLAGS_CF | !z << FLAGS_ZF;
   return z;
 }
+#endif /* !X86_INTRINSICS */
 
 const aluop_f kAluFast[8][4] = {
     {FastAdd8, FastAdd16, FastAdd32, FastAdd64},  //

--- a/configure
+++ b/configure
@@ -583,6 +583,16 @@ if [ -z "${MODE}" ] && [ -n "${JIT_POSSIBLE}" ] && [ -z "${DISABLE_JIT}" ]; then
   fi
 fi
 
+# the new intel cet instructions may interfere with jit, and only
+# offer improved security if the os and cpu both know about them;
+# we can revisit cet later when it becomes more mainstream
+if [ -n "${JIT_POSSIBLE}" ] && [ -z "${DISABLE_JIT}" ]; then
+  EXTRA_CFLAGS=-fcf-protection=none
+  if config noop "checking for -fcf-protection=none... "; then
+    CFLAGS="${CFLAGS} -fcf-protection=none"
+  fi
+fi
+
 # use the system zlib if available
 # otherwise, use our vendored copy
 ZLIB_CFLAGS="$(pkg-config --cflags zlib 2>/dev/null)"

--- a/third_party/gcc/gcc.mk
+++ b/third_party/gcc/gcc.mk
@@ -7,7 +7,7 @@ third_party/gcc/%.xz: third_party/gcc/%.xz.sha256 o/tool/sha256sum
 
 o/$(MODE)/i486/%.o: %.c o/third_party/gcc/i486/bin/i486-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/i486/bin/i486-linux-musl-gcc -static -Werror $(CFLAGS) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/i486/bin/i486-linux-musl-gcc -static -Werror $(filter-out -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/i486/%.o: %.s o/third_party/gcc/i486/bin/i486-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
@@ -19,7 +19,7 @@ o/$(MODE)/i486/%.o: %.S o/third_party/gcc/i486/bin/i486-linux-musl-gcc $(VM)
 
 o/$(MODE)/x86_64/%.o: %.c o/third_party/gcc/x86_64/bin/x86_64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/x86_64/bin/x86_64-linux-musl-gcc -static -Werror $(CFLAGS) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/x86_64/bin/x86_64-linux-musl-gcc -static -Werror $(filter-out -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/x86_64/%.o: %.s o/third_party/gcc/x86_64/bin/x86_64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
@@ -31,7 +31,7 @@ o/$(MODE)/x86_64/%.o: %.S o/third_party/gcc/x86_64/bin/x86_64-linux-musl-gcc $(V
 
 o/$(MODE)/x86_64-gcc48/%.o: %.c o/third_party/gcc/x86_64-gcc48/bin/x86_64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/x86_64-gcc48/bin/x86_64-linux-musl-gcc -static -Werror $(CFLAGS) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/x86_64-gcc48/bin/x86_64-linux-musl-gcc -static -Werror $(filter-out -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/x86_64-gcc48/%.o: %.S o/third_party/gcc/x86_64-gcc48/bin/x86_64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
@@ -39,7 +39,7 @@ o/$(MODE)/x86_64-gcc48/%.o: %.S o/third_party/gcc/x86_64-gcc48/bin/x86_64-linux-
 
 o/$(MODE)/x86_64-gcc49/%.o: %.c o/third_party/gcc/x86_64-gcc49/bin/x86_64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/x86_64-gcc49/bin/x86_64-linux-musl-gcc -static -Werror $(CFLAGS) -Wno-unused-value $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/x86_64-gcc49/bin/x86_64-linux-musl-gcc -static -Werror $(filter-out -fcf-protection=%,$(CFLAGS)) -Wno-unused-value $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/x86_64-gcc49/%.o: %.S o/third_party/gcc/x86_64-gcc49/bin/x86_64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
@@ -47,51 +47,51 @@ o/$(MODE)/x86_64-gcc49/%.o: %.S o/third_party/gcc/x86_64-gcc49/bin/x86_64-linux-
 
 o/$(MODE)/m68k/%.o: %.c o/third_party/gcc/m68k/bin/m68k-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/m68k/bin/m68k-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/m68k/bin/m68k-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/arm/%.o: %.c o/third_party/gcc/arm/bin/arm-linux-musleabi-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/arm/bin/arm-linux-musleabi-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/arm/bin/arm-linux-musleabi-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/aarch64/%.o: %.c o/third_party/gcc/aarch64/bin/aarch64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/aarch64/bin/aarch64-linux-musl-gcc -static -Werror $(CFLAGS) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/aarch64/bin/aarch64-linux-musl-gcc -static -Werror $(filter-out -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/riscv64/%.o: %.c o/third_party/gcc/riscv64/bin/riscv64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/riscv64/bin/riscv64-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/riscv64/bin/riscv64-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/mips/%.o: %.c o/third_party/gcc/mips/bin/mips-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/mips/bin/mips-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/mips/bin/mips-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/mipsel/%.o: %.c o/third_party/gcc/mipsel/bin/mipsel-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/mipsel/bin/mipsel-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/mipsel/bin/mipsel-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/mips64/%.o: %.c o/third_party/gcc/mips64/bin/mips64-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/mips64/bin/mips64-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/mips64/bin/mips64-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/mips64el/%.o: %.c o/third_party/gcc/mips64el/bin/mips64el-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/mips64el/bin/mips64el-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/mips64el/bin/mips64el-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/s390x/%.o: %.c o/third_party/gcc/s390x/bin/s390x-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/s390x/bin/s390x-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/s390x/bin/s390x-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/microblaze/%.o: %.c o/third_party/gcc/microblaze/bin/microblaze-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/microblaze/bin/microblaze-linux-musl-gcc -static -Werror $(CFLAGS) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/microblaze/bin/microblaze-linux-musl-gcc -static -Werror $(filter-out -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/powerpc/%.o: %.c o/third_party/gcc/powerpc/bin/powerpc-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/powerpc/bin/powerpc-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/powerpc/bin/powerpc-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/$(MODE)/powerpc64le/%.o: %.c o/third_party/gcc/powerpc64le/bin/powerpc64le-linux-musl-gcc $(VM)
 	@mkdir -p $(@D)
-	$(VM) o/third_party/gcc/powerpc64le/bin/powerpc64le-linux-musl-gcc -static -Werror $(filter-out -mtune=generic,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
+	$(VM) o/third_party/gcc/powerpc64le/bin/powerpc64le-linux-musl-gcc -static -Werror $(filter-out -mtune=generic -fcf-protection=%,$(CFLAGS)) $(CPPFLAGS) $(CPPFLAGS_STATIC) $(TARGET_ARCH) -c -o $@ $<
 
 o/third_party/gcc/i486/bin/i486-linux-musl-gcc:			\
 		third_party/gcc/x86_64-linux-musl__i486-linux-musl__g++-7.2.0.tar.xz


### PR DESCRIPTION
On my local PC, this patch gives a small (1.4%&mdash;1.8%) but consistent improvement in the running time of the `third_party/cosmo/2/test_suite_mpi.com` test program.  E.g.
```
PASSED (323 / 323 tests (1 skipped))
RL: took 20,104,433µs wall time
RL: ballooned to 5,740kb in size
RL: needed 20,096,321µs cpu (0% kernel)
RL: caused 887 page faults (99% memcpy)
RL: 885 context switches (0% consensual)
RL: performed 0 reads and 8 write i/o operations
```
vs. (without the patch)
```
PASSED (323 / 323 tests (1 skipped))
RL: took 20,407,807µs wall time
RL: ballooned to 5,640kb in size
RL: needed 20,399,361µs cpu (0% kernel)
RL: caused 889 page faults (99% memcpy)
RL: 661 context switches (0% consensual)
RL: performed 0 reads and 8 write i/o operations
```