### PR TITLE
Special-case `rep ret` to return flags to caller routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,9 @@ carry flag as a return value to indicate error. This should work fine
 when `STC` is used to set the carry flag, but if the code computes it
 cleverly using instructions like `SUB`, then EFLAGS might not change.
 
+As a special case, if a `RET` instruction sports a `REP` prefix, then
+Blink can return flags across the `RET`.
+
 ### Faults
 
 Blink may not report the precise program counter where a fault occurred

--- a/blink/deps.c
+++ b/blink/deps.c
@@ -85,6 +85,11 @@ int GetFlagClobbers(u64 rde) {
       return 0;
     case 0xE8:   // call
     case 0xC3:   // ret
+      if (Rep(rde)) {
+        return 0;
+      } else {
+        return -1;
+      }
     case 0x105:  // syscall
       return -1;
     case 0x000:  // add byte


### PR DESCRIPTION
This allows UPX's (https://upx.github.io/) x86-64 unpacker routines to work properly.  UPX relies on a callee being able to return a carry flag to its caller, and also just _happens_ to use `rep ret`.