### PR TITLE
Fix "warn_unused_result" errors

### DIFF
--- a/blink/blink.c
+++ b/blink/blink.c
@@ -248,7 +248,7 @@ static int Exec(char *execfn, char *prog, char **argv, char **envp) {
 }
 
 static void Print(int fd, const char *s) {
-  (void)write(fd, s, strlen(s));
+  (void)!write(fd, s, strlen(s));
 }
 
 _Noreturn static void PrintUsage(int argc, char *argv[], int rc, int fd) {

--- a/blink/getopt.c
+++ b/blink/getopt.c
@@ -74,7 +74,7 @@ static void getopt_print_badch(int argc, char *const argv[], int optopt,
   b[i + 3] = ' ';
   b[i + 4] = optopt;
   b[i + 5] = '\n';
-  write(2, b, i + 6);
+  (void)!write(2, b, i + 6);
 }
 
 /**


### PR DESCRIPTION
The compilation fails when compiling on Arch Linux using `makepkg` ([config](https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/blob/72838f981c3deb2985faf0f3ec6e4f1e8e45b0e2/makepkg.conf#L41)):

```
cc -fno-align-functions -fno-common -pthread -fpie -march=x86-64 -mtune=generic
-O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat
-Werror=format-security         -fstack-clash-protection -fcf-protection
-fno-omit-frame-pointer -fno-optimize-sibling-calls -fcf-protection=none
-U_FORTIFY_SOURCE -D_FILE_OFFSET_BITS=64 -D_DARWIN_C_SOURCE -D_DEFAULT_SOURCE
-D_BSD_SOURCE -D_GNU_SOURCE -iquote. -DCONFIG_ARGUMENTS="\"\""
-DBUILD_TOOLCHAIN="\"cc (GCC) 13.1.1 20230429\"" -DBUILD_TIMESTAMP="\"Mon Jun
5 11:09:39 UTC 2023\"" -DBLINK_COMMITS="\"\"" -DBLINK_UNAME_V="\"DEFAULT\""
-DBLINK_GITSHA="\"\"" -DBUILD_MODE="\"\""  -c -o o//blink/blink.o blink/blink.c
blink/blink.c: In function ‘Print’: blink/blink.c:251:9:

error: ignoring return value of ‘write’ declared with attribute
‘warn_unused_result’ [-Werror=unused-result]
251 |   (void)write(fd, s, strlen(s));
    | ^~~~~~~~~~~~~~~~~~~~~~~ cc1: some warnings being treated as
errors make: *** [build/rules.mk:13: o//blink/blink.o]
```

Use (void)! to avoid the error as suggested at
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425#c34.