### PR TITLE
AArch64 host fixes and optimizations

### DIFF
--- a/blink/intrin.h
+++ b/blink/intrin.h
@@ -9,5 +9,10 @@ typedef char char_xmma_t
 #else
 #define X86_INTRINSICS 0
 #endif
+#if defined(__aarch64__) && defined(__GNUC__)
+#define ARM_INTRINSICS 1
+#else
+#define ARM_INTRINSICS 0
+#endif
 
 #endif /* BLINK_INTRIN_H_ */

--- a/blink/jit.h
+++ b/blink/jit.h
@@ -84,22 +84,33 @@
 #endif
 
 #ifdef __aarch64__
-#define kArmJmp      0x14000000u  // B
-#define kArmCall     0x94000000u  // BL
-#define kArmRet      0xd65f03c0u  // RET
-#define kArmMovNex   0xf2800000u  // sets sub-word of register to immediate
-#define kArmMovZex   0xd2800000u  // load immediate into reg w/ zero-extend
-#define kArmMovSex   0x92800000u  // load 1's complement imm w/ sign-extend
-#define kArmDispMin  -33554432    // can jump -2**25 ints backward
-#define kArmDispMax  +33554431    // can jump +2**25-1 ints forward
-#define kArmDispMask 0x03ffffffu  // mask of branch displacement
-#define kArmRegOff   0            // bit offset of destination register
-#define kArmRegMask  0x0000001fu  // mask of destination register
-#define kArmImmOff   5            // bit offset of mov immediate value
-#define kArmImmMask  0x001fffe0u  // bit offset of mov immediate value
-#define kArmImmMax   0xffffu      // maximum immediate value per instruction
-#define kArmIdxOff   21           // bit offset of u16[4] sub-word index
-#define kArmIdxMask  0x00600000u  // mask of u16[4] sub-word index
+#define kArmJmp         0x14000000u  // B
+#define kArmCall        0x94000000u  // BL
+#define kArmRet         0xd65f03c0u  // RET
+#define kArmMovNex      0xf2800000u  // sets sub-word of register to immediate
+#define kArmMovZex      0xd2800000u  // load immediate into reg w/ zero-extend
+#define kArmMovSex      0x92800000u  // load 1's complement imm w/ sign-extend
+#define kArmAdr         0x10000000u  // form PC-relative byte address
+#define kArmAdrp        0x90000000u  // form PC-relative page address
+#define kArmLdrPc       0x18000000u  // load PC-relative memory into register
+                                     // (general or SIMD)
+#define kArmLdrswPc     0x98000000u  // load PC-relative short w/ sign-extend
+#define kArmPrfmPc      0xd8000000u  // prefetch PC-relative memory
+#define kArmDispMin     -33554432    // can jump -2**25 ints backward
+#define kArmDispMax     +33554431    // can jump +2**25-1 ints forward
+#define kArmDispMask    0x03ffffffu  // mask of branch displacement
+#define kArmRegOff      0            // bit offset of destination register
+#define kArmRegMask     0x0000001fu  // mask of destination register
+#define kArmImmOff      5            // bit offset of mov immediate value
+#define kArmImmMask     0x001fffe0u  // bit offset of mov immediate value
+#define kArmImmMax      0xffffu      // maximum immediate value per instruction
+#define kArmIdxOff      21           // bit offset of u16[4] sub-word index
+#define kArmIdxMask     0x00600000u  // mask of u16[4] sub-word index
+#define kArmAdrMask     0x9f000000u  // mask of ADR opcode
+#define kArmAdrpMask    0x9f000000u  // mask of ADRP opcode
+#define kArmLdrPcMask   0xbb000000u  // mask of PC-relative LDR opcodes
+#define kArmLdrswPcMask 0xff000000u  // mask of PC-relative LDRSW opcode
+#define kArmPrfmPcMask  0xff000000u  // mask of PC-relative PRFM opcode
 #endif
 
 #define JITJUMP_CONTAINER(e)   DLL_CONTAINER(struct JitJump, elem, e)

--- a/blink/loader.c
+++ b/blink/loader.c
@@ -775,6 +775,9 @@ error: unsupported executable; we need:\n\
     } else if (READ64(map) == READ64("MZqFpD='") ||
                READ64(map) == READ64("jartsr='")) {
       m->system->iscosmo = true;
+      // Cosmopolitan programs pretty much require at least 47-bit virtual
+      // addresses; if the host lacks these, then emulate them w/ software
+      if (FLAG_vabits < 47) FLAG_nolinear = true;
       if (GetElfHeader(tmp, prog, (const char *)map) == -1) exit(127);
       memcpy(map, tmp, 64);
       execstack = LoadElf(m, elf, (Elf64_Ehdr_ *)map, mapsize, fd);

--- a/blink/map.c
+++ b/blink/map.c
@@ -101,6 +101,10 @@ static int GetBitsInAddressSpace(void) {
   for (i = 16; i < 40; ++i) {
     want = UINT64_C(0x8123000000000000) >> i;
     if (want > UINTPTR_MAX) continue;
+    if (Msync((void *)(uintptr_t)want, 1, MS_ASYNC, "vabits") == 0 ||
+        errno == EBUSY) {
+      return 64 - i;
+    }
     ptr = PortableMmap((void *)(uintptr_t)want, 1, PROT_READ,
                        MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS_, -1, 0);
     if (ptr != MAP_FAILED) {


### PR DESCRIPTION
- tweak Blink to work on Linux/AArch64 environments which have less than 47 usable bits for addresses
- allow the AArch64 JITter to copy some micro-op implementations into the JIT-generated instruction stream &mdash; previously only the x86-64 JITter could do this