### PR TITLE
APPEND: avoid overrunning the buffer

### DIFF
--- a/blink/debug.c
+++ b/blink/debug.c
@@ -59,7 +59,7 @@
 
 #define MAX_BACKTRACE_LINES 64
 
-#define APPEND(...) o += snprintf(b + o, n - o, __VA_ARGS__)
+#define APPEND(...) o += snprintf(b + o, o > n ? 0 : n - o, __VA_ARGS__)
 
 _Thread_local static jmp_buf g_busted;
 

--- a/blink/hex.c
+++ b/blink/hex.c
@@ -24,7 +24,7 @@
 #include "blink/log.h"
 #include "blink/tsan.h"
 
-#define APPEND(...) oi += snprintf(ob + oi, on - oi, __VA_ARGS__)
+#define APPEND(...) oi += snprintf(ob + oi, oi > on ? 0 : on - oi, __VA_ARGS__)
 
 void DumpHex(u8 *p, size_t n) {
   int oi = 0;

--- a/blink/log.c
+++ b/blink/log.c
@@ -42,7 +42,7 @@
 
 #define DEFAULT_LOG_PATH "blink.log"
 
-#define APPEND(F, ...) n += F(b + n, PIPE_BUF - n, __VA_ARGS__)
+#define APPEND(F, ...) n += F(b + n, n > PIPE_BUF ? 0 : PIPE_BUF - n, __VA_ARGS__)
 
 static struct Log {
   pthread_once_t_ once;

--- a/blink/path.c
+++ b/blink/path.c
@@ -37,7 +37,7 @@
 #include "blink/stats.h"
 #include "blink/vfs.h"
 
-#define APPEND(...) o += snprintf(b + o, n - o, __VA_ARGS__)
+#define APPEND(...) o += snprintf(b + o, o > n ? 0 : n - o, __VA_ARGS__)
 
 #ifdef HAVE_JIT
 

--- a/blink/pml4tfmt.c
+++ b/blink/pml4tfmt.c
@@ -38,7 +38,7 @@
 #define INTERESTING_FLAGS (PAGE_U | PAGE_RW | PAGE_XD | PAGE_FILE)
 
 #define BYTES       16384
-#define APPEND(...) u->o += snprintf(u->b + u->o, BYTES - u->o, __VA_ARGS__)
+#define APPEND(...) u->o += snprintf(u->b + u->o, u->o > BYTES ? 0 : BYTES - u->o, __VA_ARGS__)
 
 struct MapMaker {
   bool t;

--- a/blink/stats.c
+++ b/blink/stats.c
@@ -26,7 +26,7 @@
 #undef DEFINE_AVERAGE
 #undef DEFINE_COUNTER
 
-#define APPEND(...) o += snprintf(b + o, n - o, __VA_ARGS__)
+#define APPEND(...) o += snprintf(b + o, o > n ? 0 : n - o, __VA_ARGS__)
 
 void PrintStats(void) {
 #ifndef NDEBUG

--- a/blink/strace.c
+++ b/blink/strace.c
@@ -39,7 +39,7 @@
 #include "blink/thread.h"
 #include "blink/util.h"
 
-#define APPEND(...) bi += snprintf(bp + bi, bn - bi, __VA_ARGS__)
+#define APPEND(...) bi += snprintf(bp + bi, bi > bn ? 0 : bn - bi, __VA_ARGS__)
 
 struct thatispacked MagicNumber {
   int x;


### PR DESCRIPTION
if two APPENDs are called one after another, and first of them cannot fit the message into the buffer, the second will end up writing its message pass the end of the buffer (due to size parameter to snprintf being unsigned).