### PR TITLE
Use PROT_MPROTECT for NetBSD mprotect restrictions

### DIFF
--- a/blink/map.c
+++ b/blink/map.c
@@ -169,6 +169,11 @@ void *Mmap(void *addr,     //
 #if LOG_MEM
   char szbuf[16];
 #endif
+#if defined(__NetBSD__)
+  if (!(flags & MAP_SHARED)) {
+    prot |= PROT_MPROTECT(PROT_EXEC | PROT_WRITE | PROT_READ);
+  }
+#endif
   res = PortableMmap(addr, length, prot, flags, fd, offset);
 #if LOG_MEM
   FormatSize(szbuf, length, 1024);


### PR DESCRIPTION
NetBSD's mprotect seems to be more restrictive than other OSes, where it does not allow less restrictive mappings than the original mmap, and can be subject to PaX restrictions. According to NetBSD documentation, there is a PROT_MPROTECT macro to define allowed protections for later uses of mprotect, without granting the permissions immediately in mmap. This can be used to ensure that the full range of protections blink could make in the course of execution are permitted.