### PR TITLE
Consolidate exit code

### DIFF
--- a/blink/bios.c
+++ b/blink/bios.c
@@ -868,7 +868,7 @@ static void OnApmService(void) {
     SetCarry(false);
   } else if (Get16(m->ax) == 0x5307 && m->bl == 1 && m->cl == 3) {
     LOGF("APM SHUTDOWN");
-    exit(0);
+    exit(EXIT_SUCCESS);
   } else {
     SetCarry(true);
   }

--- a/blink/biosrom.c
+++ b/blink/biosrom.c
@@ -145,22 +145,22 @@ void LoadBios(struct Machine *m, const char *biosprog) {
       FormatInt64(tmp, errno);
       WriteErrorString(tmp);
       WriteErrorString(")\n");
-      exit(127);
+      exit(EXIT_FAILURE_EXEC_FAILED);
     } else if ((size = st.st_size) < kBiosMinSize) {
       WriteErrorString(biosprog);
       WriteErrorString(": failed to load alternate BIOS (file too small)\n");
-      exit(127);
+      exit(EXIT_FAILURE_EXEC_FAILED);
     } else if (size > kBiosMaxSize) {
       WriteErrorString(biosprog);
       WriteErrorString(": failed to load alternate BIOS (file too large)\n");
-      exit(127);
+      exit(EXIT_FAILURE_EXEC_FAILED);
     } else if (VfsRead(fd, m->system->real + kBiosEnd - size, size) != size) {
       WriteErrorString(biosprog);
       WriteErrorString(": failed to load alternate BIOS (errno ");
       FormatInt64(tmp, errno);
       WriteErrorString(tmp);
       WriteErrorString(")\n");
-      exit(127);
+      exit(EXIT_FAILURE_EXEC_FAILED);
     }
   } else {
     // if no BIOS image file name is given, then load a default BIOS image

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -260,7 +260,7 @@ _Noreturn static void PrintUsage(int argc, char *argv[], int rc, int fd) {
 
 _Noreturn static void PrintVersion(void) {
   Print(1, VERSION);
-  exit(0);
+  exit(EXIT_SUCCESS);
 }
 
 static void GetOpts(int argc, char *argv[]) {
@@ -380,13 +380,13 @@ int main(int argc, char *argv[]) {
 #ifndef DISABLE_OVERLAYS
   if (SetOverlays(FLAG_overlays, true)) {
     WriteErrorString("bad blink overlays spec; see log for details\n");
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 #endif
 #ifndef DISABLE_VFS
   if (VfsInit(FLAG_prefix)) {
     WriteErrorString("error: vfs initialization failed\n");
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 #endif
   HandleSigs();
@@ -396,7 +396,7 @@ int main(int argc, char *argv[]) {
     WriteErrorString(": command not found: ");
     WriteErrorString(argv[optind_]);
     WriteErrorString("\n");
-    exit(127);
+    exit(EXIT_FAILURE_EXEC_FAILED);
   }
   argv[optind_] = g_pathbuf;
   return Exec(g_pathbuf, g_pathbuf, argv + optind_ + FLAG_zero, environ);

--- a/blink/blinkenlights.c
+++ b/blink/blinkenlights.c
@@ -2092,7 +2092,7 @@ static void RewindHistory(int delta) {
 static ssize_t HandleEpipe(ssize_t rc) {
   if (rc == -1 && errno == EPIPE) {
     LOGF("got EPIPE, shutting down");
-    exit(128 + EPIPE);
+    exit(EXIT_FAILURE_WITH_SIGNAL(EPIPE));
   }
   return rc;
 }
@@ -2609,7 +2609,7 @@ static void LaunchDebuggerReactively(void) {
       action |= MODAL;
     } else {
       fprintf(stderr, "ERROR: %s\n", systemfailure);
-      exit(1);
+      exit(EXIT_FAILURE);
     }
   }
 }
@@ -3093,7 +3093,7 @@ static void ReadKeyboard(void) {
       return;
     }
     fprintf(stderr, "ReadKeyboard failed: %s\n", DescribeHostErrno(errno));
-    exit(1);
+    exit(EXIT_FAILURE);
   }
   HandleKeyboard(buf);
 }
@@ -3408,7 +3408,7 @@ static void Tui(void) {
           ScrollMemoryViews();
           if (m->signals & ~m->sigmask) {
             if ((sig = ConsumeSignal(m, 0, 0))) {
-              exit(128 + sig);
+              exit(EXIT_FAILURE_WITH_SIGNAL(sig));
             }
           }
           if (!(action & CONTINUE) || interactive) {
@@ -3453,7 +3453,7 @@ static void Tui(void) {
 
 _Noreturn static void PrintVersion(void) {
   fputs(VERSION, stdout);
-  exit(0);
+  exit(EXIT_SUCCESS);
 }
 
 static void GetOpts(int argc, char *argv[]) {
@@ -3488,7 +3488,7 @@ static void GetOpts(int argc, char *argv[]) {
                   "linearization not possible on this system"
                   " (word size is %d bits and page size is %ld)\n",
                   bsr(UINTPTR_MAX) + 1, sysconf(_SC_PAGESIZE));
-          exit(1);
+          exit(EXIT_FAILURE);
         }
         break;
       case 'R':
@@ -3566,7 +3566,7 @@ int VirtualMachine(int argc, char *argv[]) {
     codepath = pathbuf;
   } else {
     fprintf(stderr, "%s: command not found: %s\n", argv[0], argv[optind_]);
-    exit(127);
+    exit(EXIT_FAILURE_EXEC_FAILED);
   }
   optind_++;
   do {
@@ -3601,7 +3601,7 @@ int VirtualMachine(int argc, char *argv[]) {
       }
       if (tty == -1) {
         WriteErrorString("failed to open /dev/tty\n");
-        exit(1);
+        exit(EXIT_FAILURE);
       }
       ttyin = tty;
       ttyout = tty;
@@ -3647,7 +3647,7 @@ void TerminateSignal(struct Machine *m, int sig, int code) {
     LOGF("terminating due to signal %s code=%d", DescribeSignal(sig), code);
     WriteErrorString("\r\033[K\033[J"
                      "terminating due to signal; see log\n");
-    exit(128 + sig);
+    exit(EXIT_FAILURE_WITH_SIGNAL(sig));
   }
 }
 
@@ -3700,13 +3700,13 @@ int main(int argc, char *argv[]) {
 #ifndef DISABLE_OVERLAYS
   if (SetOverlays(FLAG_overlays, true)) {
     WriteErrorString("bad blink overlays spec; see log for details\n");
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 #endif
 #ifndef DISABLE_VFS
   if (VfsInit(FLAG_prefix)) {
     WriteErrorString("error: vfs initialization failed\n");
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 #endif
 #ifdef HAVE_JIT

--- a/blink/demangle.c
+++ b/blink/demangle.c
@@ -135,7 +135,7 @@ static void SpawnCxxFilt(void) {
     if (pipefds[1][0] > 1) unassert(!close(pipefds[1][0]));
     if (pipefds[1][1] > 1) unassert(!close(pipefds[1][1]));
     execv(executable, (char *const[]){(char *)cxxfilt, 0});
-    _exit(127);
+    _exit(EXIT_FAILURE_EXEC_FAILED);
   }
   unassert(!close(pipefds[0][1]));
   unassert(!close(pipefds[1][0]));

--- a/blink/errfd.c
+++ b/blink/errfd.c
@@ -27,6 +27,8 @@
 #include "blink/thread.h"
 #include "blink/tunables.h"
 
+#define EXIT_FAILURE_ERRFD_INIT 200
+
 static int g_errfd;
 
 int WriteErrorString(const char *buf) {
@@ -49,5 +51,5 @@ int WriteError(int fd, const char *buf, int len) {
 void WriteErrorInit(void) {
   if (g_errfd) return;
   g_errfd = fcntl(2, F_DUPFD_CLOEXEC, kMinBlinkFd);
-  if (g_errfd == -1) exit(200);
+  if (g_errfd == -1) exit(EXIT_FAILURE_ERRFD_INIT);
 }

--- a/blink/machine.h
+++ b/blink/machine.h
@@ -23,6 +23,9 @@
 #include "blink/tunables.h"
 #include "blink/x86.h"
 
+#define EXIT_FAILURE_EXEC_FAILED 127
+#define EXIT_FAILURE_WITH_SIGNAL(sig) 128 + sig
+
 #define kArgRde   1
 #define kArgDisp  2
 #define kArgUimm0 3

--- a/blink/memorymalloc.c
+++ b/blink/memorymalloc.c
@@ -282,7 +282,7 @@ void KillOtherThreads(struct System *s) {
   struct timespec deadline;
   if (atomic_exchange(&s->killer, true)) {
     FreeMachine(g_machine);
-    pthread_exit(0);
+    pthread_exit(EXIT_SUCCESS);
   }
 StartOver:
   unassert(s == g_machine->system);
@@ -740,6 +740,8 @@ static void RemoveVirtual(struct System *s, i64 virt, i64 size,
   }
 }
 
+#define EXIT_FAILURE_MMAP_PANIC 250
+
 _Noreturn static void PanicDueToMmap(void) {
 #ifndef NDEBUG
   WriteErrorString(
@@ -748,7 +750,7 @@ _Noreturn static void PanicDueToMmap(void) {
   WriteErrorString(
       "unrecoverable mmap() crisis: Blink was built with NDEBUG\n");
 #endif
-  exit(250);
+  exit(EXIT_FAILURE_MMAP_PANIC);
 }
 
 static int FailDueToHostAlignment(i64 virt, long pagesize, const char *kind) {
@@ -937,7 +939,7 @@ i64 ReserveVirtual(struct System *s, i64 virt, i64 size, u64 flags, int fd,
         if (!(pt & PAGE_V)) {
           if ((pt = AllocatePageTable(s)) == -1) {
             WriteErrorString("mmap() crisis: ran out of page table memory\n");
-            exit(250);
+            exit(EXIT_FAILURE_MMAP_PANIC);
           }
           StorePte(mi, pt);
         }

--- a/blink/syscall.c
+++ b/blink/syscall.c
@@ -392,7 +392,7 @@ _Noreturn void SysExit(struct Machine *m, int rc) {
   } else {
     ClearChildTid(m);
     FreeMachine(m);
-    pthread_exit(0);
+    pthread_exit(EXIT_SUCCESS);
   }
 #else
   SysExitGroup(m, rc);


### PR DESCRIPTION
Exiting with EXIT_SUCCESS and EXIT_FAILURE are defined in ANSI C11, aligning the README description to indicate that blink is written in ANSI C11. Additionally, to ensure consistency in exit calls, EXIT_FAILURE_EXEC_FAILED, EXIT_FAILURE_WITH_SIGNAL, EXIT_FAILURE_ERRFD_INIT and EXIT_FAILURE_MMAP_PANIC are introduced, replacing numeric exit codes with semantic macros.