### PR TITLE
Enable compilation on Solaris

### DIFF
--- a/blink/flock.h
+++ b/blink/flock.h
@@ -1,0 +1,42 @@
+#ifndef BLINK_FLOCK_H_
+#define BLINK_FLOCK_H_
+
+#if defined(sun) || defined(__sun)
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+#define LOCK_SH 1  // shared lock
+#define LOCK_EX 2  // exclusive lock
+#define LOCK_UN 8  // unlock
+#define LOCK_NB 4  // non-blocking
+
+static int flock(int fd, int operation) {
+  struct flock fl = {0};
+
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0; // Lock the whole file
+
+  switch (operation & (LOCK_EX | LOCK_SH | LOCK_UN)) {
+    case LOCK_EX:
+      fl.l_type = F_WRLCK;
+      break;
+    case LOCK_SH:
+      fl.l_type = F_RDLCK;
+      break;
+    case LOCK_UN:
+      fl.l_type = F_UNLCK;
+      break;
+    default:
+      errno = EINVAL;
+      return -1;
+  }
+
+  return fcntl(fd, (operation & LOCK_NB) ? F_SETLK : F_SETLKW, &fl);
+}
+
+#endif
+
+#endif /* BLINK_FLOCK_H_ */

--- a/blink/syscall.h
+++ b/blink/syscall.h
@@ -6,6 +6,7 @@
 
 #include "blink/builtin.h"
 #include "blink/fds.h"
+#include "blink/flock.h"
 #include "blink/machine.h"
 #include "blink/ndelay.h"
 #include "blink/types.h"

--- a/tool/flock.c
+++ b/tool/flock.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/file.h>
+#include "../blink/flock.h"
 
 int main(int argc, char *argv[]) {
   if (argc != 3) return 1;


### PR DESCRIPTION
These changes allow Blink to be built with the default configuration on Solaris, tested on a Solaris 11.4 VM. The main addition is to introduce emulation of flock with fcntl, since the former is not available on new Solaris versions.

Additionally, fd_set handling is modified to use heap memory instead of stack memory, since this can exceed the frame size.