### PR TITLE
Implement DragonFlyBSD support

### DIFF
--- a/blink/cpuid.c
+++ b/blink/cpuid.c
@@ -20,17 +20,18 @@
 #include "blink/endian.h"
 #include "blink/machine.h"
 
-#define INTEL    "GenuineIntel"
-#define BLINK    "GenuineBlink"
-#define LINUX_   "Linux\0\0\0\0\0\0\0"
-#define FREEBSD_ "FreeBSD\0\0\0\0\0\0"
-#define NETBSD_  "NetBSD\0\0\0\0\0\0"
-#define OPENBSD_ "OpenBSD\0\0\0\0\0"
-#define XNU_     "XNU\0\0\0\0\0\0\0\0\0"
-#define WINDOWS_ "Windows\0\0\0\0\0"
-#define CYGWIN_  "Cygwin\0\0\0\0\0\0"
-#define HAIKU_   "Haiku\0\0\0\0\0\0\0"
-#define UNKNOWN_ "Unknown\0\0\0\0\0\0"
+#define INTEL         "GenuineIntel"
+#define BLINK         "GenuineBlink"
+#define LINUX_        "Linux\0\0\0\0\0\0\0"
+#define FREEBSD_      "FreeBSD\0\0\0\0\0\0"
+#define NETBSD_       "NetBSD\0\0\0\0\0\0"
+#define OPENBSD_      "OpenBSD\0\0\0\0\0"
+#define DRAGONFLYBSD_ "DragonFlyBSD"
+#define XNU_          "XNU\0\0\0\0\0\0\0\0\0"
+#define WINDOWS_      "Windows\0\0\0\0\0"
+#define CYGWIN_       "Cygwin\0\0\0\0\0\0"
+#define HAIKU_        "Haiku\0\0\0\0\0\0\0"
+#define UNKNOWN_      "Unknown\0\0\0\0\0\0"
 
 #ifdef __COSMOPOLITAN__
 #define OS                  \
@@ -49,6 +50,8 @@
 #define OS NETBSD_
 #elif defined(__OpenBSD__)
 #define OS OPENBSD_
+#elif defined(__DragonFly__)
+#define OS DRAGONFLYBSD_
 #elif defined(__APPLE__)
 #define OS XNU_
 #elif defined(__CYGWIN__)

--- a/blink/elf.h
+++ b/blink/elf.h
@@ -629,5 +629,6 @@ char *GetElfSectionNameStringTable(const Elf64_Ehdr_ *, size_t);
 void *GetElfSectionAddress(const Elf64_Ehdr_ *, size_t, const Elf64_Shdr_ *);
 Elf64_Sym_ *GetElfSymbolTable(const Elf64_Ehdr_ *, size_t, int *);
 i64 GetElfMemorySize(const Elf64_Ehdr_ *, size_t, i64 *);
+const char *GetElfOsNameInNoteTag(const Elf64_Ehdr_ *, size_t);
 
 #endif /* BLINK_ELF_H_ */

--- a/blink/loader.c
+++ b/blink/loader.c
@@ -293,6 +293,16 @@ static bool IsHaikuExecutable(Elf64_Ehdr_ *ehdr, size_t size) {
 #endif
 }
 
+static bool IsDragonflybsdExecutable(Elf64_Ehdr_ *ehdr, size_t size) {
+#ifdef __DragonFly__
+  const char *name = GetElfOsNameInNoteTag(ehdr, size);
+  if (name && !strcmp(name, "DragonFly")) {
+    return true;
+  }
+#endif
+  return false;
+}
+
 static bool IsShebangExecutable(void *image, size_t size) {
   return size >= 2 && ((char *)image)[0] == '#' && ((char *)image)[1] == '!';
 }
@@ -340,6 +350,10 @@ bool IsSupportedExecutable(const char *path, void *image, size_t size) {
     }
     if (IsHaikuExecutable(ehdr, size)) {
       ExplainWhyItCantBeEmulated(path, "ELF is Haiku executable");
+      return false;
+    }
+    if (IsDragonflybsdExecutable(ehdr, size)) {
+      ExplainWhyItCantBeEmulated(path, "ELF is DragonFlyBSD executable");
       return false;
     }
 #if defined(__ELF__) && !defined(__linux)


### PR DESCRIPTION
This patch adds support for running Blink on DragonFlyBSD. cpuid now has support for detecting DragonFlyBSD, and Blink's execve can detect if the requested executable is built for DragonFlyBSD using a helper to extract the OS name from ELF notes.